### PR TITLE
Non-bot updates to AQ2-TNG

### DIFF
--- a/change.txt
+++ b/change.txt
@@ -89,10 +89,6 @@ From 2.81
 - Chat replacements (like %k) now work when dead too, and invalid options no longer attempt to resolve as printf replacements.
 - Fixed some issues with "%" in voting printf statements.
 - Clients no longer get additional map votes to spend when the map changes by other means.
-* Bots branch no longer messes up multiplayer view models (player_state_t was not the expected size).
-- Tweaked bot aiming so they're not such ridiculous crack shots in certain circumstances.
-- Bots are no longer counted in voting, and you can kickvote bots with any number of players (minimum is ignored).
-+ Added optional gender to 'botdata.cfg' parsing.
 
 From 2.8
 - Radio kill count was missing for falling death

--- a/change.txt
+++ b/change.txt
@@ -89,6 +89,10 @@ From 2.81
 - Chat replacements (like %k) now work when dead too, and invalid options no longer attempt to resolve as printf replacements.
 - Fixed some issues with "%" in voting printf statements.
 - Clients no longer get additional map votes to spend when the map changes by other means.
+* Bots branch no longer messes up multiplayer view models (player_state_t was not the expected size).
+- Tweaked bot aiming so they're not such ridiculous crack shots in certain circumstances.
+- Bots are no longer counted in voting, and you can kickvote bots with any number of players (minimum is ignored).
++ Added optional gender to 'botdata.cfg' parsing.
 
 From 2.8
 - Radio kill count was missing for falling death

--- a/change.txt
+++ b/change.txt
@@ -71,6 +71,24 @@ From 2.81
 + Disable leg damage sound when falling and fall damage disabled
 + New cvar "motdname" which tells which file to read the MOTD from
 + Better auto joining which calculates the correct team when you select "Auto-join team" from menu rather select the correct menu item for you
+- Fixed all compiler warnings for gcc 4.8 with -Wall on Linux x86_64.
++ Added automatic detection of MinGW environment to Makefile.
+- Chase camera no longer gets stuck up or down after in-eyes spectating someone who looks wildly up or down (usually bots).
+- Center-handed weapon icon for in-eyes spectator now reflects your 'hand' setting rather than the person you're watching.
++ Added 'hud_team_icon', 'hud_item_cycle', and 'hud_noscore' to let server admins tweak the hud elements a bit.  Default teamplay HUD no longer has your frags.
+- HUD elements like health and ammo no longer show up when free spectating.
++ Added 'allow_hoarding' to control whether players are allowed to carry multiple of the same unique weapon or special item (by default they can't anymore).
++ Added 'use_flashlight' option so server admin can decide to allow the flashlight in non-darkmatch.
+- No more lasersight or splats on the sky.
+- Splats and bulletholes now stick to moving objects.
++ Added 'bholelife', 'splatlife', 'shelllife', and 'shelllimit' to give server operators greater control over these effects.  Default values retain old behavior.
++ Teamplay scoreboard page 2 now shows team, kills, and deaths in all submodes.  Disabled 'use_newscore' by default because it's fairly redundant now.
+- If you enable 'use_newscore', it can also show 3-team scores.
+- Changed items names for "clips" to "magazines" and "machinegun" to "MP5".
++ Added 'sv slap' command.  Admins can use it to unstick players, or just for fun.  With great power comes great responsibility.
+- Chat replacements (like %k) now work when dead too, and invalid options no longer attempt to resolve as printf replacements.
+- Fixed some issues with "%" in voting printf statements.
+- Clients no longer get additional map votes to spend when the map changes by other means.
 
 From 2.8
 - Radio kill count was missing for falling death

--- a/source/Makefile
+++ b/source/Makefile
@@ -1,6 +1,6 @@
 # GNU Make required
 #
-# Tested platforms: Linux x86
+# Tested platforms: Linux x86, Linux x86_64, MinGW x86
 #
 
 GIT_REV=$(shell git rev-parse --short HEAD)
@@ -37,13 +37,18 @@ VERSION=$(REL_VERSION)
 endif
 
 CC?=gcc
-BASE_CFLAGS=-DC_ONLY -DVERSION=\"$(VERSION)\"
+BASE_CFLAGS=-DC_ONLY -DVERSION=\"$(VERSION)\" -Wall -fno-strict-aliasing
 
 #use these cflags to optimize it
 ifdef DEBUG
-	CFLAGS=$(BASE_CFLAGS) -g -Wall
+	CFLAGS=$(BASE_CFLAGS) -g
 else
 	CFLAGS=$(BASE_CFLAGS) -O2
+
+	# If it's not for release, allow machine-specific optimizations.
+	ifneq ($(RELEASE),yes)
+		CFLAGS+=-march=native -mtune=native
+	endif
 endif
 
 ifdef X86
@@ -57,8 +62,12 @@ DO_LINK=$(CC) $(CFLAGS) $(SHLIBLDFLAGS) -o $@ $(GAME_OBJS) $(SHLIBLIBS)
 SHLIBEXT?=so
 SHLIBLDFLAGS?=-shared
 
+ifneq (,$(findstring MINGW,$(SYSTEM))$(findstring CYGWIN,$(SYSTEM)))
+WIN32=yes
+endif
+
 ifdef WIN32
-CC=i686-w64-mingw32-gcc
+#CC=i686-w64-mingw32-gcc
 CFLAGS+=-DWIN32
 ARCH=x86
 SHLIBEXT=dll

--- a/source/a_cmds.c
+++ b/source/a_cmds.c
@@ -224,6 +224,9 @@ void LaserSightThink(edict_t * self)
 
 	vectoangles(tr.plane.normal, self->s.angles);
 	VectorCopy(tr.endpos, self->s.origin);
+
+	self->s.modelindex = (tr.surface && (tr.surface->flags & SURF_SKY)) ? gi.modelindex("sprites/null.sp2") : gi.modelindex("sprites/lsight.sp2");
+
 	gi.linkentity(self);
 	self->nextthink = level.time + 0.1;
 }

--- a/source/a_ctf.c
+++ b/source/a_ctf.c
@@ -344,7 +344,7 @@ void ResetPlayers()
 
 void CTFSwapTeams()
 {
-	//vec3_t point;
+	//vec3_t point;  // FIXME: This was never used.
 	edict_t *ent;
 	int i;
 
@@ -1545,7 +1545,7 @@ void CTFCapReward(edict_t * ent)
 {
 	gclient_t *client;
 	gitem_t *item;
-	//edict_t etemp;
+	//edict_t etemp;  // FIXME: This was never used.
 	int was_bandaging = 0;
 	int band;
 	int player_weapon;

--- a/source/a_ctf.c
+++ b/source/a_ctf.c
@@ -51,17 +51,23 @@
 
 ctfgame_t ctfgame;
 
-cvar_t *ctf;
-cvar_t *ctf_forcejoin;
-cvar_t *ctf_mode;
-cvar_t *ctf_dropflag;
-cvar_t *ctf_respawn;
-cvar_t *ctf_model;
+cvar_t *ctf = NULL;
+cvar_t *ctf_forcejoin = NULL;
+cvar_t *ctf_mode = NULL;
+cvar_t *ctf_dropflag = NULL;
+cvar_t *ctf_respawn = NULL;
+cvar_t *ctf_model = NULL;
+
+//-----------------------------------------------------------------------------
+
+void ChangePlayerSpawns();
+void MakeAllLivePlayersObservers();
+void ED_CallSpawn( edict_t *ent );
 
 /*--------------------------------------------------------------------------*/
 
-gitem_t *flag1_item;
-gitem_t *flag2_item;
+gitem_t *flag1_item = NULL;
+gitem_t *flag2_item = NULL;
 
 void CTFInit(void)
 {
@@ -338,7 +344,7 @@ void ResetPlayers()
 
 void CTFSwapTeams()
 {
-	vec3_t point;
+	//vec3_t point;
 	edict_t *ent;
 	int i;
 
@@ -1539,7 +1545,7 @@ void CTFCapReward(edict_t * ent)
 {
 	gclient_t *client;
 	gitem_t *item;
-	edict_t etemp;
+	//edict_t etemp;
 	int was_bandaging = 0;
 	int band;
 	int player_weapon;

--- a/source/a_ctf.h
+++ b/source/a_ctf.h
@@ -101,6 +101,9 @@ char *CTFTeamName (int team);
 char *CTFOtherTeamName (int team);
 void CTFAssignTeam (gclient_t * who);
 edict_t *SelectCTFSpawnPoint (edict_t * ent);
+
+void CTFResetFlags(void);
+
 qboolean CTFPickup_Flag (edict_t * ent, edict_t * other);
 void CTFDrop_Flag (edict_t * ent, gitem_t * item);
 void CTFEffects (edict_t * player);

--- a/source/a_game.c
+++ b/source/a_game.c
@@ -533,6 +533,7 @@ void stuffcmd(edict_t * ent, char *c)
 void unicastSound(edict_t *ent, int soundIndex, float volume)
 {
     int mask = MASK_ENTITY_CHANNEL;
+
     if (volume != 1.0)
         mask |= MASK_VOLUME;
  

--- a/source/a_game.c
+++ b/source/a_game.c
@@ -533,7 +533,6 @@ void stuffcmd(edict_t * ent, char *c)
 void unicastSound(edict_t *ent, int soundIndex, float volume)
 {
     int mask = MASK_ENTITY_CHANNEL;
- 
     if (volume != 1.0)
         mask |= MASK_VOLUME;
  
@@ -834,7 +833,8 @@ void EjectShell(edict_t * self, vec3_t start, int toggle)
 
 	shell->owner = self;
 	shell->touch = ShellTouch;
-	shell->nextthink = level.time + 1.2 - (shells * .05);
+	float shell_subtract = shelllimit->value ? (1. / shelllimit->value) : 0.;
+	shell->nextthink = level.time + shelllife->value * (1.0 - (shells * shell_subtract));
 	shell->think = ShellDie;
 	shell->classname = "shell";
 
@@ -851,17 +851,11 @@ edict_t *FindEdictByClassnum(char *classname, int classnum)
 	int i;
 	edict_t *it;
 
-	for (i = 0; i < globals.num_edicts; i++) {
+	for (i = 0; i < globals.num_edicts; i++)
+	{
 		it = &g_edicts[i];
-		if (!it->classname)
-			continue;
-		if (!it->classnum)
-			continue;
-		if (Q_stricmp(it->classname, classname) == 0) {
-			if (it->classnum == classnum)
-				return it;
-		}
-
+		if (it->classname && (it->classnum == classnum) && (strcasecmp(it->classname, classname) == 0))
+			return it;
 	}
 
 	return NULL;
@@ -869,6 +863,42 @@ edict_t *FindEdictByClassnum(char *classname, int classnum)
 }
 
 /********* Bulletholes/wall stuff ***********/
+
+// Decal/splat attached to some moving entity.
+void DecalOrSplatThink( edict_t *self )
+{
+	if( level.time >= self->wait )
+	{
+		G_FreeEdict(self);
+		return;
+	}
+
+	self->nextthink = level.time + FRAMETIME;
+
+	if( self < self->movetarget )
+	{
+		// If the object we're attached to hasn't been updated yet this frame,
+		// we need to move ahead one frame's worth so we stay aligned with it.
+		VectorScale( self->movetarget->velocity, FRAMETIME, self->s.origin );
+		VectorAdd( self->movetarget->s.origin, self->s.origin, self->s.origin );
+		VectorScale( self->movetarget->avelocity, FRAMETIME, self->s.angles );
+		VectorAdd( self->movetarget->s.angles, self->s.angles, self->s.angles );
+	}
+	else
+	{
+		VectorCopy( self->movetarget->s.origin, self->s.origin );
+		VectorCopy( self->movetarget->s.angles, self->s.angles );
+	}
+
+	vec3_t fwd, right, up;
+	AngleVectors( self->s.angles, fwd, right, up ); // At this point, this is the angles of the entity we attached to.
+	self->s.origin[0] += fwd[0] * self->move_origin[0] + right[0] * self->move_origin[1] + up[0] * self->move_origin[2];
+	self->s.origin[1] += fwd[1] * self->move_origin[0] + right[1] * self->move_origin[1] + up[1] * self->move_origin[2];
+	self->s.origin[2] += fwd[2] * self->move_origin[0] + right[2] * self->move_origin[1] + up[2] * self->move_origin[2];
+	VectorAdd( self->s.angles, self->move_angles, self->s.angles );
+	VectorCopy( self->movetarget->velocity, self->velocity );
+	VectorCopy( self->movetarget->avelocity, self->avelocity );
+}
 
 void DecalDie(edict_t * self)
 {
@@ -882,6 +912,17 @@ void AddDecal(edict_t * self, trace_t * tr)
 	if (bholelimit->value < 1)
 		return;
 
+	qboolean attached = false;
+
+	if (tr->ent && ( (strncasecmp( tr->ent->classname, "func_door", 9 ) == 0)
+	               || (strcasecmp( tr->ent->classname, "func_plat" ) == 0)
+	               || (strcasecmp( tr->ent->classname, "func_rotating" ) == 0)
+	               || (strcasecmp( tr->ent->classname, "func_train" ) == 0)
+	               || (strcasecmp( tr->ent->classname, "func_button" ) == 0) ))
+	{
+		attached = true;
+	}
+
 	decal = G_Spawn();
 	++decals;
 
@@ -891,6 +932,7 @@ void AddDecal(edict_t * self, trace_t * tr)
 	dec = FindEdictByClassnum("decal", decals);
 
 	if (dec) {
+		dec->think = DecalDie;
 		dec->nextthink = level.time + .1;
 	}
 
@@ -899,16 +941,32 @@ void AddDecal(edict_t * self, trace_t * tr)
 	decal->s.modelindex = gi.modelindex("models/objects/holes/hole1/hole.md2");
 	VectorCopy(tr->endpos, decal->s.origin);
 	vectoangles(tr->plane.normal, decal->s.angles);
+	decal->s.angles[ROLL] = crandom() * 180.f;
+
 	decal->owner = self;
-	decal->classnum = decals;
 	decal->touch = NULL;
-	decal->nextthink = level.time + 20;
-	decal->think = DecalDie;
+	decal->nextthink = level.time + bholelife->value;
+	decal->think = bholelife->value ? DecalDie : NULL;
 	decal->classname = "decal";
+	decal->classnum = decals;
 
 	gi.linkentity(decal);
 	if ((tr->ent) && (0 == Q_stricmp("func_explosive", tr->ent->classname))) {
 		CGF_SFX_AttachDecalToGlass(tr->ent, decal);
+	}
+	else if( attached )
+	{
+		decal->think = DecalOrSplatThink;
+		decal->wait = decal->nextthink;
+		decal->movetarget = tr->ent;
+		vec3_t fwd, right, up, offset;
+		AngleVectors( tr->ent->s.angles, fwd, right, up );
+		VectorSubtract( decal->s.origin, tr->ent->s.origin, offset );
+		decal->move_origin[0] = DotProduct( offset, fwd );
+		decal->move_origin[1] = DotProduct( offset, right );
+		decal->move_origin[2] = DotProduct( offset, up );
+		VectorSubtract( decal->s.angles, tr->ent->s.angles, decal->move_angles );
+		DecalOrSplatThink( decal );
 	}
 }
 
@@ -925,6 +983,17 @@ void AddSplat(edict_t * self, vec3_t point, trace_t * tr)
 	if (splatlimit->value < 1)
 		return;
 
+	qboolean attached = false;
+
+	if (tr->ent && ( (strncasecmp( tr->ent->classname, "func_door", 9 ) == 0)
+	               || (strcasecmp( tr->ent->classname, "func_plat" ) == 0)
+	               || (strcasecmp( tr->ent->classname, "func_rotating" ) == 0)
+	               || (strcasecmp( tr->ent->classname, "func_train" ) == 0)
+	               || (strcasecmp( tr->ent->classname, "func_button" ) == 0) ))
+	{
+		attached = true;
+	}
+
 	splat = G_Spawn();
 	++splats;
 
@@ -934,6 +1003,7 @@ void AddSplat(edict_t * self, vec3_t point, trace_t * tr)
 	spt = FindEdictByClassnum("splat", splats);
 
 	if (spt) {
+		spt->think = SplatDie;
 		spt->nextthink = level.time + .1;
 	}
 
@@ -951,12 +1021,12 @@ void AddSplat(edict_t * self, vec3_t point, trace_t * tr)
 	VectorCopy(point, splat->s.origin);
 
 	vectoangles(tr->plane.normal, splat->s.angles);
+	splat->s.angles[ROLL] = crandom() * 180.f;
 
 	splat->owner = self;
 	splat->touch = NULL;
-	splat->nextthink = level.time + 25;	// - (splats * .05);
-
-	splat->think = SplatDie;
+	splat->nextthink = level.time + splatlife->value; // - (splats * .05);
+	splat->think = splatlife->value ? SplatDie : NULL;
 	splat->classname = "splat";
 	splat->classnum = splats;
 
@@ -964,73 +1034,110 @@ void AddSplat(edict_t * self, vec3_t point, trace_t * tr)
 	if ((tr->ent) && (0 == Q_stricmp("func_explosive", tr->ent->classname))) {
 		CGF_SFX_AttachDecalToGlass(tr->ent, splat);
 	}
+	else if( attached )
+	{
+		splat->think = DecalOrSplatThink;
+		splat->wait = splat->nextthink;
+		splat->movetarget = tr->ent;
+		vec3_t fwd, right, up, offset;
+		AngleVectors( tr->ent->s.angles, fwd, right, up );
+		VectorSubtract( splat->s.origin, tr->ent->s.origin, offset );
+		splat->move_origin[0] = DotProduct( offset, fwd );
+		splat->move_origin[1] = DotProduct( offset, right );
+		splat->move_origin[2] = DotProduct( offset, up );
+		VectorSubtract( splat->s.angles, tr->ent->s.angles, splat->move_angles );
+		DecalOrSplatThink( splat );
+	}
 }
 
 /* %-variables for chat msgs */
 
 void GetWeaponName(edict_t * ent, char *buf)
 {
-	if (ent->client->pers.weapon) {
+	if (ent->solid != SOLID_NOT && ent->deadflag != DEAD_DEAD && ent->client->pers.weapon)
+	{
 		strcpy(buf, ent->client->pers.weapon->pickup_name);
 		return;
 	}
 
-	strcpy(buf, "No Weapon");
+	strcpy(buf, "no weapon");
 }
 
 void GetItemName(edict_t * ent, char *buf)
 {
 	int i;
 
-	for(i = 0; i<ITEM_COUNT; i++)
+	if (ent->solid != SOLID_NOT && ent->deadflag != DEAD_DEAD)
 	{
-		if (INV_AMMO(ent, tnums[i])) {
-			strcpy(buf, GET_ITEM(tnums[i])->pickup_name);
-			return;
+		for(i = 0; i<ITEM_COUNT; i++)
+		{
+			if (INV_AMMO(ent, tnums[i]))
+			{
+				strcpy(buf, GET_ITEM(tnums[i])->pickup_name);
+				return;
+			}
 		}
 	}
 
-	strcpy(buf, "No Item");
+	strcpy(buf, "no item");
 }
 
 void GetHealth(edict_t * ent, char *buf)
 {
-	sprintf(buf, "%d", ent->health);
+	if (ent->solid != SOLID_NOT && ent->deadflag != DEAD_DEAD)
+		sprintf(buf, "%d", ent->health);
+	else
+		sprintf(buf, "0");
 }
 
 void GetAmmo(edict_t * ent, char *buf)
 {
 	int ammo;
 
-	if (ent->client->pers.weapon) {
+	if (ent->solid != SOLID_NOT && ent->deadflag != DEAD_DEAD && ent->client->pers.weapon)
+	{
 		switch (ent->client->curr_weap) {
 		case MK23_NUM:
-			sprintf(buf, "%d rounds (%d extra clips)",
-				ent->client->mk23_rds, ent->client->pers.inventory[ent->client->ammo_index]);
+			sprintf(buf, "%d round%s (%d extra mag%s)",
+				ent->client->mk23_rds, ent->client->mk23_rds == 1 ? "" : "s",
+				ent->client->pers.inventory[ent->client->ammo_index],
+				ent->client->pers.inventory[ent->client->ammo_index] == 1 ? "" : "s");
 			return;
 		case MP5_NUM:
-			sprintf(buf, "%d rounds (%d extra clips)",
-				ent->client->mp5_rds, ent->client->pers.inventory[ent->client->ammo_index]);
+			sprintf(buf, "%d round%s (%d extra mag%s)",
+				ent->client->mp5_rds, ent->client->mp5_rds == 1 ? "" : "s",
+				ent->client->pers.inventory[ent->client->ammo_index],
+				ent->client->pers.inventory[ent->client->ammo_index] == 1 ? "" : "s");
 			return;
 		case M4_NUM:
-			sprintf(buf, "%d rounds (%d extra clips)",
-				ent->client->m4_rds, ent->client->pers.inventory[ent->client->ammo_index]);
+			sprintf(buf, "%d round%s (%d extra mag%s)",
+				ent->client->m4_rds, ent->client->m4_rds == 1 ? "" : "s",
+				ent->client->pers.inventory[ent->client->ammo_index],
+				ent->client->pers.inventory[ent->client->ammo_index] == 1 ? "" : "s");
 			return;
 		case M3_NUM:
-			sprintf(buf, "%d shells (%d extra shells)",
-				ent->client->shot_rds, ent->client->pers.inventory[ent->client->ammo_index]);
+			sprintf(buf, "%d shell%s (%d extra shell%s)",
+				ent->client->shot_rds, ent->client->shot_rds == 1 ? "" : "s",
+				ent->client->pers.inventory[ent->client->ammo_index],
+				ent->client->pers.inventory[ent->client->ammo_index] == 1 ? "" : "s");
 			return;
 		case HC_NUM:
-			sprintf(buf, "%d shells (%d extra shells)",
-				ent->client->cannon_rds, ent->client->pers.inventory[ent->client->ammo_index]);
+			sprintf(buf, "%d shell%s (%d extra shell%s)",
+				ent->client->cannon_rds, ent->client->cannon_rds == 1 ? "" : "s",
+				ent->client->pers.inventory[ent->client->ammo_index],
+				ent->client->pers.inventory[ent->client->ammo_index] == 1 ? "" : "s");
 			return;
 		case SNIPER_NUM:
-			sprintf(buf, "%d rounds (%d extra rounds)",
-				ent->client->sniper_rds, ent->client->pers.inventory[ent->client->ammo_index]);
+			sprintf(buf, "%d round%s (%d extra round%s)",
+				ent->client->sniper_rds, ent->client->sniper_rds == 1 ? "" : "s",
+				ent->client->pers.inventory[ent->client->ammo_index],
+				ent->client->pers.inventory[ent->client->ammo_index] == 1 ? "" : "s");
 			return;
 		case DUAL_NUM:
-			sprintf(buf, "%d rounds (%d extra clips)",
-				ent->client->dual_rds, ent->client->pers.inventory[ent->client->ammo_index]);
+			sprintf(buf, "%d round%s (%d extra mag%s)",
+				ent->client->dual_rds, ent->client->dual_rds == 1 ? "" : "s",
+				ent->client->pers.inventory[ent->client->ammo_index],
+				ent->client->pers.inventory[ent->client->ammo_index] == 1 ? "" : "s");
 			return;
 		case KNIFE_NUM:
 			ammo = INV_AMMO(ent, KNIFE_NUM);
@@ -1048,7 +1155,7 @@ void GetAmmo(edict_t * ent, char *buf)
 
 void GetNearbyTeammates(edict_t * self, char *buf)
 {
-	unsigned char nearby_teammates[8][16];
+	char nearby_teammates[8][16];
 	int nearby_teammates_num = 0, l;
 	edict_t *ent = NULL;
 

--- a/source/a_team.c
+++ b/source/a_team.c
@@ -1374,7 +1374,7 @@ int UpdateJoinMenu (edict_t * ent)
 	else
 		joinmenu[9].text = NULL;
 
-	return 0;
+	return 0;  // FIXME: Should this ever return anything else?  Why does it have a return value?
 }
 
 // AQ2:TNG END
@@ -1758,7 +1758,7 @@ void SpawnPlayers ()
 			ent->client->resp.last_damaged_part = 0;
 			ent->client->resp.last_damaged_players[0] = '\0';
 			//AQ2:TNG END
-			PutClientInServer(ent);
+			PutClientInServer (ent);
 			AddToTransparentList (ent);
 		}
 	}

--- a/source/a_team.c
+++ b/source/a_team.c
@@ -2608,8 +2608,8 @@ void A_NewScoreboardMessage(edict_t * ent)
 void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 {
 	char string[1400] = "";
-	// char damage[50] = "";
-	//gclient_t *cl;
+	//char damage[50] = "";  // FIXME: This was only used in commented-out parts of the code.
+	//gclient_t *cl;  // FIXME: This was set but never used.
 	edict_t *cl_ent = NULL;
 	int maxsize = 1000, i = 0, j = 0, k = 0;
 
@@ -2790,7 +2790,7 @@ void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 			{
 				if (i < total[j] && stoppedat[j] == -1)	// print next team member...
 				{
-					//cl = &game.clients[sorted[j][i]];
+					//cl = &game.clients[sorted[j][i]];  // FIXME: This was never used.
 					cl_ent = g_edicts + 1 + sorted[j][i];
 					if (cl_ent->solid != SOLID_NOT && cl_ent->deadflag != DEAD_DEAD)
 						totalaliveprinted[j]++;

--- a/source/a_team.c
+++ b/source/a_team.c
@@ -324,7 +324,7 @@ int	teamCount = 2;
 #define MAX_SPAWNS 512		// max DM spawn points supported
 
 edict_t *potential_spawns[MAX_SPAWNS];
-int num_potential_spawns;
+int num_potential_spawns = 0;
 edict_t *teamplay_spawns[MAX_TEAMS];
 trace_t trace_t_temp;		// used by our trace replace macro in ax_team.h
 
@@ -1294,7 +1294,7 @@ int UpdateJoinMenu (edict_t * ent)
 	static char team1players[28];
 	static char team2players[28];
 	static char team3players[28];
-	int num1 = 0, num2 = 0, num3 = 0, i;
+	int num1 = 0, num2 = 0, num3 = 0, i = 0;
 
 	if (ctf->value)
 	{
@@ -1373,6 +1373,8 @@ int UpdateJoinMenu (edict_t * ent)
 		joinmenu[9].text = team3players;
 	else
 		joinmenu[9].text = NULL;
+
+	return 0;
 }
 
 // AQ2:TNG END
@@ -1756,7 +1758,7 @@ void SpawnPlayers ()
 			ent->client->resp.last_damaged_part = 0;
 			ent->client->resp.last_damaged_players[0] = '\0';
 			//AQ2:TNG END
-			PutClientInServer (ent);
+			PutClientInServer(ent);
 			AddToTransparentList (ent);
 		}
 	}
@@ -2544,9 +2546,12 @@ void A_NewScoreboardMessage(edict_t * ent)
 	}
 
 	// print teams
-	for (i = TEAM1; i <= TEAM2; i++)
+	for (i = TEAM1; i <= (use_3teams->value ? TEAM3 : TEAM2); i++)
 	{
-		sprintf(buf, "xv 44 yv %d string2 \"%3d %-11s Frg Tim Png\"", line++ * lineh, teams[i].score, teams[i].name);
+		sprintf(buf, "xv 44 yv %d string2 \"%s\"", line++ * lineh, teams[i].name);
+		strcat(string, buf);
+
+		sprintf(buf, "xv 44 yv %d string2 \"Wins:%2d %-7s Frg Tim Png\"", line++ * lineh, teams[i].score, "");
 		strcat(string, buf);
 
 		sprintf(buf, "xv 44 yv %d string2 \"%s\" ",
@@ -2574,20 +2579,22 @@ void A_NewScoreboardMessage(edict_t * ent)
 			edict_t *cl_ent = g_edicts + 1 + sorted[i][j];
 			int alive = (cl_ent->solid != SOLID_NOT && cl_ent->deadflag != DEAD_DEAD);
 
-			sprintf(buf, "xv 44 yv %d string%c \"%-15s %3d %3d %3d\"",
+			char ping_buf[ 4 ] = "   ";
+			snprintf( ping_buf, 4, "%3d", (cl->ping > 999 ? 999 : cl->ping) );
+			sprintf(buf, "xv 44 yv %d string%c \"%-15s %3d %3d %s\"",
 					line++ * lineh,
 					(alive && dead ? '2' : ' '),
 					cl->pers.netname,
 					cl->resp.score,
 					(level.framenum - cl->resp.enterframe) / 600,
-					(cl->ping > 999 ? 999 : cl->ping));
+					ping_buf);
 			strcat(string, buf);
 		}
 
 		line++;
 	}
 
-	string[1024] = '\0';
+	string[1023] = '\0';
 
 	gi.WriteByte (svc_layout);
 	gi.WriteString (string);
@@ -2599,10 +2606,11 @@ void A_NewScoreboardMessage(edict_t * ent)
 //AQ2:TNG - Slicer Modified Scores for Match Mode
 void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 {
-	char string[1400], damage[50];
-	gclient_t *cl;
-	edict_t *cl_ent;
-	int maxsize = 1000, i, j, k;
+	char string[1400] = "";
+	// char damage[50] = "";
+	//gclient_t *cl;
+	edict_t *cl_ent = NULL;
+	int maxsize = 1000, i = 0, j = 0, k = 0;
 
 
 	if (ent->client->scoreboardnum == 1)
@@ -2623,7 +2631,7 @@ void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 		int otherLines, scoreWidth = 3;
 
 		// new scoreboard for regular teamplay up to 16 players
-		if (use_newscore->value && teamplay->value && !use_3teams->value && !matchmode->value && !ctf->value) {
+		if (use_newscore->value && teamplay->value /* && !use_3teams->value */ && !matchmode->value && !ctf->value) {
 			return A_NewScoreboardMessage(ent);
 		}
 
@@ -2781,7 +2789,7 @@ void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 			{
 				if (i < total[j] && stoppedat[j] == -1)	// print next team member...
 				{
-					cl = &game.clients[sorted[j][i]];
+					//cl = &game.clients[sorted[j][i]];
 					cl_ent = g_edicts + 1 + sorted[j][i];
 					if (cl_ent->solid != SOLID_NOT && cl_ent->deadflag != DEAD_DEAD)
 						totalaliveprinted[j]++;
@@ -2912,6 +2920,10 @@ void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 					if (score > game.clients[sorted[j]].resp.score)
 						break;
 					if (score == game.clients[sorted[j]].resp.score &&
+						game.clients[i].resp.deaths < game.clients[sorted[j]].resp.deaths)
+							break;
+					if (score == game.clients[sorted[j]].resp.score &&
+						game.clients[i].resp.deaths == game.clients[sorted[j]].resp.deaths &&
 						game.clients[i].resp.damage_dealt > game.clients[sorted[j]].resp.damage_dealt)
 							break;
 				}
@@ -2930,6 +2942,14 @@ void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 			"xv 0 yv 32 string2 \"Player          Time Ping\" "
 			"xv 0 yv 40 string2 \"žžžžžžžžžžžžžŸ žžŸ žžŸ\" ");
 		}
+		else
+		// Raptor007: I think this works well for any teamplay mode.
+		{
+			strcpy (string,
+			"xv 0 yv 32 string2 \"Team Player          Time Ping Kills Deaths\" "
+			"xv 0 yv 40 string2 \"žžŸ žžžžžžžžžžžžžŸ žžŸ žžŸ žžžŸ žžžžŸ\" ");
+		}
+/*
 		else if (teamdm->value)
 		{
 			if(matchmode->value) {
@@ -2955,6 +2975,7 @@ void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 			"xv 0 yv 32 string2 \"Frags Player          Time Ping Damage Kills\" "
 			"xv 0 yv 40 string2 \"žžžŸ žžžžžžžžžžžžžŸ žžŸ žžŸ žžžžŸ žžžŸ\" ");
 		}
+*/
       /*
          {
          strcpy (string, "xv 0 yv 32 string2 \"Player          Time Ping\" "
@@ -2973,14 +2994,30 @@ void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 			ping = game.clients[sorted[i]].ping;
 			if (ping > 999)
 				ping = 999;
+			char ping_buf[ 4 ] = "   ";
+			snprintf( ping_buf, 4, "%3d", ping );
 
 			if (noscore->value)
 			{
-				sprintf(string + strlen(string), "xv 0 yv %d string \"%-15s %4d %4d\" ",
+				sprintf(string + strlen(string), "xv 0 yv %d string \"%-15s %4d %4s\" ",
 					48 + i * 8,	game.clients[sorted[i]].pers.netname,
 					(level.framenum - game.clients[sorted[i]].resp.enterframe) / 600,
-					ping);
+					ping_buf);
 			}
+			else
+			{
+				sprintf(string + strlen(string), "xv 0 yv %d string \" %c%c%c %-15s %4d %4s %5i %6i\"",
+					48 + i * 8,
+					game.clients[sorted[i]].resp.team ? game.clients[sorted[i]].resp.team + '0' : ' ',
+					game.clients[sorted[i]].resp.captain ? 'C' : ' ',
+					game.clients[sorted[i]].resp.subteam ? 'S' : ' ',
+					game.clients[sorted[i]].pers.netname,
+					(level.framenum - game.clients[sorted[i]].resp.enterframe) / 600,
+					ping_buf,
+					game.clients[sorted[i]].resp.score,
+					game.clients[sorted[i]].resp.deaths);
+			}
+/*
 			else
 			{
 				if(teamdm->value) {
@@ -2996,11 +3033,11 @@ void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 				}
 
 
-				sprintf(string + strlen(string), "xv 0 yv %d string \"%5d %-15s %4d %4d %6s",
+				sprintf(string + strlen(string), "xv 0 yv %d string \"%5d %-15s %4d %4s %6s",
 					48 + i * 8,	game.clients[sorted[i]].resp.score,
 					game.clients[sorted[i]].pers.netname,
 					(level.framenum - game.clients[sorted[i]].resp.enterframe) / 600,
-					ping, damage);
+					ping_buf, damage);
 
 				if(matchmode->value)
 				{
@@ -3015,7 +3052,7 @@ void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 						game.clients[sorted[i]].resp.kills);
 				}
 			}
-
+*/
 			if (strlen(string) > (maxsize - 100) && i < (total - 2))
 			{
 				sprintf (string + strlen (string), "xv 0 yv %d string \"..and %d more\" ",

--- a/source/a_team.c
+++ b/source/a_team.c
@@ -2578,6 +2578,7 @@ void A_NewScoreboardMessage(edict_t * ent)
 			gclient_t *cl = &game.clients[sorted[i][j]];
 			edict_t *cl_ent = g_edicts + 1 + sorted[i][j];
 			int alive = (cl_ent->solid != SOLID_NOT && cl_ent->deadflag != DEAD_DEAD);
+			int leveltime = (level.framenum - cl->resp.enterframe) / 600;
 
 			char ping_buf[ 4 ] = "   ";
 			snprintf( ping_buf, 4, "%3d", (cl->ping > 999 ? 999 : cl->ping) );
@@ -2586,7 +2587,7 @@ void A_NewScoreboardMessage(edict_t * ent)
 					(alive && dead ? '2' : ' '),
 					cl->pers.netname,
 					cl->resp.score,
-					(level.framenum - cl->resp.enterframe) / 600,
+					(leveltime > 9999 ? 9999 : leveltime),
 					ping_buf);
 			strcat(string, buf);
 		}

--- a/source/a_tourney.c
+++ b/source/a_tourney.c
@@ -296,10 +296,10 @@ TourneyReadIni (void)
   parse_t parse;
   int clevel = 0;
   char *mytok = NULL;
-  //qboolean inevent = false;
+  //qboolean inevent = false;  // FIXME: This was set but never used.
 
   t_eventcount = 0;
-  //inevent = false;
+  //inevent = false;  // FIXME: This was never used.
   if (ParseStartFile (GAMEVERSION "/" TOURNEYINI, &parse) == true)
     {
       while ((mytok = ParseNextToken (&parse, STDSEPERATOR)))

--- a/source/a_tourney.c
+++ b/source/a_tourney.c
@@ -294,13 +294,12 @@ void
 TourneyReadIni (void)
 {
   parse_t parse;
-  int clevel;
-  char *mytok;
-  qboolean inevent;
+  int clevel = 0;
+  char *mytok = NULL;
+  //qboolean inevent = false;
 
   t_eventcount = 0;
-  clevel = 0;
-  inevent = false;
+  //inevent = false;
   if (ParseStartFile (GAMEVERSION "/" TOURNEYINI, &parse) == true)
     {
       while ((mytok = ParseNextToken (&parse, STDSEPERATOR)))

--- a/source/a_vote.c
+++ b/source/a_vote.c
@@ -284,8 +284,7 @@ void Cmd_Maplist_f (edict_t * ent, char *dummy)
 //
 void _MapInitClient (edict_t * ent)
 {
-	//ent->client->resp.mapvote = NULL;
-	_RemoveVoteFromMap(ent);
+	ent->client->resp.mapvote = NULL;
 }
 
 //

--- a/source/a_vote.c
+++ b/source/a_vote.c
@@ -490,10 +490,10 @@ qboolean _iCheckMapVotes (void)
 
 votelist_t *MapWithMostVotes (float *p)
 {
-	//int i;
+	//int i;  // FIXME: This was never used.
 	float p_most = 0.0f, votes = 0.f;
 	votelist_t *search = NULL, *most = NULL;
-	//edict_t *e;
+	//edict_t *e;  // FIXME: This was never used.
 
 	if (map_votes == NULL)
 		return (NULL);

--- a/source/a_vote.c
+++ b/source/a_vote.c
@@ -215,7 +215,7 @@ void Cmd_Maplist_f (edict_t * ent, char *dummy)
 	most = MapWithMostVotes (&p_most);
 
 	sprintf (msg_buf,
-		"List of maps that can be voted on:\nRequire more than %d%% votes (%.2f)\n\n",
+		"List of maps that can be voted on:\nRequire more than %d%%%% votes (%.2f)\n\n",
 		(int)mapvote_pass->value, mapvote_pass->value / 100.0f);
 
 	lines = chars_on_line = 0;
@@ -267,7 +267,7 @@ void Cmd_Maplist_f (edict_t * ent, char *dummy)
 
 	Q_strncatz(msg_buf, "\n\n", sizeof(msg_buf));
 	Com_sprintf (tmp_buf, sizeof(tmp_buf),
-		"%d/%d (%.2f%%) clients voted\n%d client%s minimum (%d%% required)",
+		"%d/%d (%.2f%%%%) clients voted\n%d client%s minimum (%d%%%% required)",
 		map_num_votes, map_num_clients,
 		(float)( (float)map_num_votes /
 		(float)(map_num_clients > 0 ? map_num_clients : 1) * 100.0f),	// TempFile changed to percentual display
@@ -284,7 +284,8 @@ void Cmd_Maplist_f (edict_t * ent, char *dummy)
 //
 void _MapInitClient (edict_t * ent)
 {
-	ent->client->resp.mapvote = NULL;
+	//ent->client->resp.mapvote = NULL;
+	_RemoveVoteFromMap(ent);
 }
 
 //
@@ -394,7 +395,7 @@ qboolean _CheckMapVotes (void)
 
 	if (_iCheckMapVotes() == true)
 	{
-		gi.bprintf (PRINT_HIGH, "More than %i%% map votes reached.\n", (int)mapvote_pass->value);
+		gi.bprintf (PRINT_HIGH, "More than %i%%%% map votes reached.\n", (int)mapvote_pass->value);
 		return true;
 	}
 	return false;
@@ -453,7 +454,7 @@ cvar_t *_InitMapVotelist (ini_t * ini)
 	mapvote_need = gi.cvar ("mapvote_need",
 		ReadIniStr (ini, MAPVOTESECTION, "mapvote_need", buf, "0"), CVAR_LATCH);
 	mapvote_pass = gi.cvar ("mapvote_pass",
-		ReadIniStr (ini, MAPVOTESECTION, "mapvote_pass", buf, "50"), CVAR_LATCH);
+		ReadIniStr (ini, MAPVOTESECTION, "mapvote_pass", buf, "51"), CVAR_LATCH);
 
 	return (use_mapvote);
 }
@@ -489,10 +490,10 @@ qboolean _iCheckMapVotes (void)
 
 votelist_t *MapWithMostVotes (float *p)
 {
-	int i;
-	float p_most = 0.0f, votes;
-	votelist_t *search, *most;
-	edict_t *e;
+	//int i;
+	float p_most = 0.0f, votes = 0.f;
+	votelist_t *search = NULL, *most = NULL;
+	//edict_t *e;
 
 	if (map_votes == NULL)
 		return (NULL);
@@ -841,10 +842,10 @@ void _DoKick (edict_t * target)
 {
 	char buf[128];
 
-	sprintf (buf, "more than %i%% voted for.", (int) kickvote_pass->value);
+	sprintf (buf, "more than %i%%%% voted for.", (int) kickvote_pass->value);
 	_ClrKickVotesOn (target);
 	if (kickvote_tempban->value)
-		Ban_TeamKiller(target, 1); //Ban for 1 game
+		Ban_TeamKiller( target, (int)kickvote_tempban->value ); // Ban for some games (usually 1)
 
 	KickClient (target, buf);
 }
@@ -895,9 +896,6 @@ void _CheckKickVote (void)
 	kickvotechanged = false;
 	playernum = _numclients ();
 
-	if (playernum < kickvote_need->value)
-		return;
-
 	maxvotes = 0;
 	mtarget = NULL;
 	playervoted = 0;
@@ -932,6 +930,8 @@ void _CheckKickVote (void)
 	Mostkickpercent = (float) (((float) maxvotes / (float) playernum) * 100.0);
 	Allkickvotes = (float) (((float) playervoted / (float) playernum) * 100.0);
 
+	if (playernum < kickvote_min->value)
+		return;
 	if (Allkickvotes < kickvote_need->value)
 		return;
 	if (Mostkickpercent < kickvote_pass->value)
@@ -1059,8 +1059,8 @@ void Cmd_Kicklist_f (edict_t * ent, char *argument)
 
   // adding vote settings
   Com_sprintf (tbuf, sizeof(tbuf), "Vote rules: %i client%s min. (currently %i),\n" \
-	   "%.1f%% must have voted overall (currently %.1f%%)\n" \
-	   "and %.1f%%%% on the same (currently %.1f%% on %s),\n" \
+	   "%.1f%%%% must have voted overall (currently %.1f%%%%)\n" \
+	   "and %.1f%%%% on the same (currently %.1f%%%% on %s),\n" \
 	   "kicked players %s be temporarily banned.\n\n",
 	   (int) (kickvote_min->value),
 	   (kickvote_min->value == 1) ? " " : "s ",
@@ -1163,7 +1163,7 @@ Cmd_Configlist_f (edict_t * ent, char *dummy)
 	most = ConfigWithMostVotes (&p_most);
 
 	sprintf (msg_buf,
-		"List of configs that can be voted on:\nRequire more than %d%% votes (%.2f)\n\n",
+		"List of configs that can be voted on:\nRequire more than %d%%%% votes (%.2f)\n\n",
 		(int) cvote_pass->value,
 		(float) ((float) cvote_pass->value / 100.0));
 
@@ -1205,7 +1205,7 @@ Cmd_Configlist_f (edict_t * ent, char *dummy)
 
 	Q_strncatz (msg_buf, "\n\n", sizeof(msg_buf));
 	Com_sprintf (tmp_buf, sizeof(tmp_buf), 
-		"%d/%d (%.2f%%) clients voted\n%d client%s minimum (%d%% required)",
+		"%d/%d (%.2f%%%%) clients voted\n%d client%s minimum (%d%%%% required)",
 		config_num_votes, config_num_clients,
 		(float) ((float) config_num_votes / (float) (config_num_clients >
 		0 ? config_num_clients : 1) * 100),
@@ -1311,7 +1311,7 @@ qboolean _ConfigMostVotesStr (char *buf)
 	most = ConfigWithMostVotes (&p_most);
 	if (most != NULL)
 	{
-		sprintf (buf, "%s (%.2f%%)", most->configname, p_most * 100.0);
+		sprintf (buf, "%s (%.2f%%%%)", most->configname, p_most * 100.0);
 		return true;
 	}
 	else
@@ -1352,7 +1352,7 @@ cvar_t *_InitConfiglist (ini_t * ini)
 	cvote_need = gi.cvar ("cvote_need",
 		ReadIniStr (ini, CONFIGVOTESECTION, "cvote_need", buf, "0"), CVAR_LATCH);
 	cvote_pass = gi.cvar ("cvote_pass",
-		ReadIniStr (ini, CONFIGVOTESECTION, "cvote_pass", buf, "50"), CVAR_LATCH);
+		ReadIniStr (ini, CONFIGVOTESECTION, "cvote_pass", buf, "51"), CVAR_LATCH);
 	return (use_cvote);
 }
 
@@ -1950,7 +1950,7 @@ void _CheckScrambleVote (void)
 
 	if (numvotes > 0)
 	{
-		sprintf (buf, "Scramble: %d votes (%.1f%%), need %.1f%%\n", numvotes, votes, scramblevote_pass->value);
+		sprintf (buf, "Scramble: %d votes (%.1f%%%%), need %.1f%%%%\n", numvotes, votes, scramblevote_pass->value);
 		gi.bprintf (PRINT_HIGH, strtostr2 (buf));
 	}
 

--- a/source/a_vote.c
+++ b/source/a_vote.c
@@ -432,16 +432,22 @@ void _MapWithMostVotes (void)
 }
 
 //
-cvar_t *_InitMapVotelist (ini_t * ini)
+void _ClearMapVotes (void)
 {
-	char buf[1024];
-
-	// note that this is done whether we have set "use_mapvote" or not!
 	map_votes = NULL;
 	map_num_maps = 0;
 	map_num_votes = 0;
 	map_num_clients = 0;
 	map_need_to_check_votes = true;
+}
+
+//
+cvar_t *_InitMapVotelist (ini_t * ini)
+{
+	char buf[1024];
+
+	// note that this is done whether we have set "use_mapvote" or not!
+	_ClearMapVotes();
 	ReadMaplistFile ();
 
 	use_mapvote = gi.cvar ("use_mapvote", "0", 0);

--- a/source/a_vote.c
+++ b/source/a_vote.c
@@ -434,8 +434,6 @@ void _MapWithMostVotes (void)
 //
 void _ClearMapVotes (void)
 {
-	map_votes = NULL;
-	map_num_maps = 0;
 	map_num_votes = 0;
 	map_num_clients = 0;
 	map_need_to_check_votes = true;
@@ -447,6 +445,8 @@ cvar_t *_InitMapVotelist (ini_t * ini)
 	char buf[1024];
 
 	// note that this is done whether we have set "use_mapvote" or not!
+	map_votes = NULL;
+	map_num_maps = 0;
 	_ClearMapVotes();
 	ReadMaplistFile ();
 

--- a/source/a_vote.h
+++ b/source/a_vote.h
@@ -40,6 +40,7 @@ void _RemoveVoteFromMap (edict_t * ent);
 void _MapExitLevel (char *NextMap);
 qboolean _CheckMapVotes (void);
 void _MapWithMostVotes (void);
+void _ClearMapVotes (void);
 cvar_t *_InitMapVotelist (ini_t * ini);
 void MapVoteMenu (edict_t * ent, pmenu_t * p);
 

--- a/source/a_xgame.c
+++ b/source/a_xgame.c
@@ -703,6 +703,7 @@ void ParseSayText (edict_t * ent, char *text, size_t size)
 				break;
 			//AQ2:TNG END
 			default:
+				*pbuf++ = '%'; // Turn into double-percent for printf safety.
 				*pbuf++ = *p++;
 				break;
 			}

--- a/source/a_xvote.c
+++ b/source/a_xvote.c
@@ -36,7 +36,7 @@ vote_t xvotelist[] = {
    NULL,			// cvar
    _InitMapVotelist,		// InitGame 
    NULL,			// ExitGame 
-   NULL,			// InitLevel
+   _ClearMapVotes,		// InitLevel
    _MapExitLevel,		// ExitLevel
    _MapInitClient,		// InitClient
    NULL,			// ClientConnect

--- a/source/g_chase.c
+++ b/source/g_chase.c
@@ -72,23 +72,26 @@ UpdateChaseCam (edict_t * ent)
 
   targ = ent->client->resp.last_chase_target = ent->client->chase_target;
 
-  if (ent->client->chase_mode == 1)
+  if (ent->client->chase_mode == 1)  // 3rd-person
     {
       ent->client->clientNum = ent - g_edicts - 1;
       ent->client->ps.gunindex = ent->client->ps.gunframe = 0;
       ent->client->desired_fov = 90;
       ent->client->ps.fov = 90;
 
-      if (ent->client->resp.cmd_angles[PITCH] > 89)
-	ent->client->resp.cmd_angles[PITCH] = 89;
-      if (ent->client->resp.cmd_angles[PITCH] < -89)
-	ent->client->resp.cmd_angles[PITCH] = -89;
+      VectorCopy (ent->client->resp.cmd_angles, angles);
+      for ( i = 0; i < 3; i ++ )
+        angles[i] += SHORT2ANGLE(ent->client->ps.pmove.delta_angles[i]);
+      //if (angles[PITCH] > 89)
+      //  angles[PITCH] = 89;
+      //else if (angles[PITCH] < -89)
+      //  angles[PITCH] = -89;
+      VectorCopy (angles, ent->client->ps.viewangles);
+      VectorCopy (angles, ent->client->v_angle);
 
       VectorCopy (targ->s.origin, ownerv);
-
       ownerv[2] += targ->viewheight;
 
-      VectorCopy (ent->client->ps.viewangles, angles);
       AngleVectors (angles, forward, right, NULL);
       VectorNormalize (forward);
       VectorMA (ownerv, -150, forward, o);
@@ -139,15 +142,8 @@ UpdateChaseCam (edict_t * ent)
 	ent->client->ps.pmove.pm_type = PM_FREEZE;
 
       VectorCopy (goal, ent->s.origin);
-
-      for (i = 0; i < 3; i++)
-	ent->client->ps.pmove.delta_angles[i] =
-	  ANGLE2SHORT (ent->client->v_angle[i] -
-		       ent->client->resp.cmd_angles[i]);
-
-      VectorCopy (ent->client->resp.cmd_angles, ent->client->ps.viewangles);
     }
-  else             // chase_mode == 2
+  else  // in-eyes (chase_mode == 2)
     {
       ent->client->clientNum = targ - g_edicts - 1;
       VectorCopy (targ->client->v_angle, angles);
@@ -171,16 +167,11 @@ UpdateChaseCam (edict_t * ent)
       ent->client->ps.fov = targ->client->ps.fov;
       ent->client->desired_fov = targ->client->ps.fov;
 
-      for (i = 0; i < 3; i++)
-	ent->client->ps.pmove.delta_angles[i] =
-	  ANGLE2SHORT (targ->client->v_angle[i] -
-		       ent->client->resp.cmd_angles[i]);
-
       if (targ->deadflag)
 	{
 	  ent->client->ps.viewangles[ROLL] = 40;
-	  ent->client->ps.viewangles[PITCH] = -15;
-	  ent->client->ps.viewangles[YAW] = targ->client->killer_yaw;
+	  ent->client->ps.viewangles[PITCH] = ent->client->v_angle[PITCH] = -15;
+	  ent->client->ps.viewangles[YAW] = ent->client->v_angle[YAW] = targ->client->killer_yaw;
 	}
       else
 	{
@@ -188,6 +179,9 @@ UpdateChaseCam (edict_t * ent)
 	  VectorCopy (angles, ent->client->v_angle);
 	}
     }
+
+  for ( i = 0; i < 3; i ++ )
+    ent->client->ps.pmove.delta_angles[i] = ANGLE2SHORT(ent->client->v_angle[i] - ent->client->resp.cmd_angles[i]);
 
   ent->viewheight = 0;
   ent->client->ps.pmove.pm_flags |= PMF_NO_PREDICTION;

--- a/source/g_chase.c
+++ b/source/g_chase.c
@@ -82,10 +82,13 @@ UpdateChaseCam (edict_t * ent)
       VectorCopy (ent->client->resp.cmd_angles, angles);
       for ( i = 0; i < 3; i ++ )
         angles[i] += SHORT2ANGLE(ent->client->ps.pmove.delta_angles[i]);
+
+      // Raptor007: Disabled because this would cause the camera to get stuck looking up or down.
       //if (angles[PITCH] > 89)
       //  angles[PITCH] = 89;
       //else if (angles[PITCH] < -89)
       //  angles[PITCH] = -89;
+
       VectorCopy (angles, ent->client->ps.viewangles);
       VectorCopy (angles, ent->client->v_angle);
 
@@ -96,9 +99,10 @@ UpdateChaseCam (edict_t * ent)
       VectorNormalize (forward);
       VectorMA (ownerv, -150, forward, o);
 
-// not sure if this should be left in... -FB
-//              if (o[2] < targ->s.origin[2] + 20)  
-//                      o[2] = targ->s.origin[2] + 20;
+      // not sure if this should be left in... -FB
+      // Raptor007: No, I think this was used for rear-view chasecam (following target's view) to see over the model's head.
+      //if (o[2] < targ->s.origin[2] + 20)
+      //  o[2] = targ->s.origin[2] + 20;
 
       // jump animation lifts
       if (!targ->groundentity)

--- a/source/g_cmds.c
+++ b/source/g_cmds.c
@@ -215,7 +215,6 @@
 #include "m_player.h"
 
 void Cmd_NextMap_f( edict_t *ent );
-void Cmd_Placenode_f( edict_t *ent );
 
 qboolean FloodCheck (edict_t *ent)
 {
@@ -1291,7 +1290,7 @@ void Cmd_Say_f (edict_t * ent, qboolean team, qboolean arg0, qboolean partner_ms
 	int j, /*i,*/ offset_of_text;
 	edict_t *other;
 	char *args, text[256], *s;
-	//gclient_t *cl;
+	//gclient_t *cl;  // FIXME: This was never used.
 	int meing = 0, isadmin = 0;
 
 	if (gi.argc() < 2 && !arg0)
@@ -1468,7 +1467,7 @@ void Cmd_Say_f (edict_t * ent, qboolean team, qboolean arg0, qboolean partner_ms
 	if (strlen(text) >= 254)
 		text[254] = 0;
 	
-	//if (ent->solid != SOLID_NOT && ent->deadflag != DEAD_DEAD)
+	//if (ent->solid != SOLID_NOT && ent->deadflag != DEAD_DEAD)  // Disabled so we parse dead chat too.
 	{
 		s = strchr(text + offset_of_text, '%');
 		if(s) {

--- a/source/g_cmds.c
+++ b/source/g_cmds.c
@@ -1287,7 +1287,8 @@ Cmd_Say_f
 */
 void Cmd_Say_f (edict_t * ent, qboolean team, qboolean arg0, qboolean partner_msg)
 {
-	int j, /*i,*/ offset_of_text;
+	//int i;  // FIXME: This was never used.
+	int j, offset_of_text;
 	edict_t *other;
 	char *args, text[256], *s;
 	//gclient_t *cl;  // FIXME: This was never used.

--- a/source/g_cmds.c
+++ b/source/g_cmds.c
@@ -214,6 +214,9 @@
 #include "g_local.h"
 #include "m_player.h"
 
+void Cmd_NextMap_f( edict_t *ent );
+void Cmd_Placenode_f( edict_t *ent );
+
 qboolean FloodCheck (edict_t *ent)
 {
 	if (flood_threshold->value)
@@ -1285,10 +1288,10 @@ Cmd_Say_f
 */
 void Cmd_Say_f (edict_t * ent, qboolean team, qboolean arg0, qboolean partner_msg)
 {
-	int j, i, offset_of_text;
+	int j, /*i,*/ offset_of_text;
 	edict_t *other;
 	char *args, text[256], *s;
-	gclient_t *cl;
+	//gclient_t *cl;
 	int meing = 0, isadmin = 0;
 
 	if (gi.argc() < 2 && !arg0)
@@ -1465,7 +1468,7 @@ void Cmd_Say_f (edict_t * ent, qboolean team, qboolean arg0, qboolean partner_ms
 	if (strlen(text) >= 254)
 		text[254] = 0;
 	
-	if (ent->solid != SOLID_NOT && ent->deadflag != DEAD_DEAD)
+	//if (ent->solid != SOLID_NOT && ent->deadflag != DEAD_DEAD)
 	{
 		s = strchr(text + offset_of_text, '%');
 		if(s) {

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -1135,8 +1135,8 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 			&& (targ->movetype != MOVETYPE_PUSH)
 			&& (targ->movetype != MOVETYPE_STOP))
 		{
-			vec3_t kvel, flydir;
-			float mass;
+			vec3_t kvel = {0.f,0.f,0.f}, flydir = {0.f,0.f,0.f};
+			float mass = 0.f;
 
 			if (mod != MOD_FALLING)
 			{

--- a/source/g_grapple.c
+++ b/source/g_grapple.c
@@ -1,9 +1,12 @@
 #include "g_local.h"
 /*------------------------------------------------------------------------*/
-/* GRAPPLE																  */
+/* GRAPPLE                                                                */
 /*------------------------------------------------------------------------*/
 
-cvar_t *use_grapple;
+qboolean CheckTeamDamage( edict_t *targ, edict_t *attacker );
+void Weapon_Generic( edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, int FRAME_IDLE_LAST, int FRAME_DEACTIVATE_LAST, int FRAME_RELOAD_LAST, int FRAME_LASTRD_LAST, int *pause_frames, int *fire_frames, void (*fire)( edict_t * ent ) );
+
+cvar_t *use_grapple = NULL;
 
 // ent is player
 void CTFPlayerResetGrapple(edict_t *ent)

--- a/source/g_items.c
+++ b/source/g_items.c
@@ -332,6 +332,10 @@ qboolean Pickup_Special (edict_t * ent, edict_t * other)
 	if (other->client->unique_item_total >= unique_items->value)
 		return false;
 
+	// Don't allow picking up multiple of the same special item.
+	if( (! allow_hoarding->value) && other->client->pers.inventory[ITEM_INDEX(ent->item)] )
+		return false;
+
 	AddItem(other, ent->item);
 
 	if(!(ent->spawnflags & (DROPPED_ITEM | DROPPED_PLAYER_ITEM)) && item_respawnmode->value)
@@ -430,14 +434,14 @@ void Drop_Special (edict_t * ent, gitem_t * item)
 void DropSpecialItem (edict_t * ent)
 {
 	// this is the order I'd probably want to drop them in...       
-	if (INV_AMMO(ent, BAND_NUM))
-		Drop_Special (ent, GET_ITEM(BAND_NUM));
+	if (INV_AMMO(ent, LASER_NUM))
+		Drop_Special (ent, GET_ITEM(LASER_NUM));
 	else if (INV_AMMO(ent, SLIP_NUM))
 		Drop_Special (ent, GET_ITEM(SLIP_NUM));
 	else if (INV_AMMO(ent, SIL_NUM))
 		Drop_Special (ent, GET_ITEM(SIL_NUM));
-	else if (INV_AMMO(ent, LASER_NUM))
-		Drop_Special (ent, GET_ITEM(LASER_NUM));
+	else if (INV_AMMO(ent, BAND_NUM))
+		Drop_Special (ent, GET_ITEM(BAND_NUM));
 	else if (INV_AMMO(ent, HELM_NUM))
 		Drop_Special (ent, GET_ITEM(HELM_NUM));
 	else if (INV_AMMO(ent, KEV_NUM))
@@ -2128,7 +2132,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    MK23_NAME,
    0,
    1,
-   "Pistol Clip",
+   MK23_AMMO_NAME,
    IT_WEAPON,
    NULL,
    0,
@@ -2152,7 +2156,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    MP5_NAME,
    0,
    0,
-   "Machinegun Magazine",
+   MP5_AMMO_NAME,
    IT_WEAPON,
    NULL,
    0,
@@ -2174,7 +2178,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    M4_NAME,
    0,
    0,
-   "M4 Clip",
+   M4_AMMO_NAME,
    IT_WEAPON,
    NULL,
    0,
@@ -2196,7 +2200,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    M3_NAME,
    0,
    0,
-   "12 Gauge Shells",
+   SHOTGUN_AMMO_NAME,
    IT_WEAPON,
    NULL,
    0,
@@ -2218,7 +2222,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    HC_NAME,
    0,
    0,
-   "12 Gauge Shells",
+   SHOTGUN_AMMO_NAME,
    IT_WEAPON,
    NULL,
    0,
@@ -2240,7 +2244,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    SNIPER_NAME,
    0,
    0,
-   "AP Sniper Ammo",
+   SNIPER_AMMO_NAME,
    IT_WEAPON,
    NULL,
    0,
@@ -2262,7 +2266,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    DUAL_NAME,
    0,
    0,
-   "Pistol Clip",
+   MK23_AMMO_NAME,
    IT_WEAPON,
    NULL,
    0,
@@ -2450,7 +2454,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    "models/items/ammo/clip/tris.md2", 0,
    NULL,
 /* icon */ "a_clip",
-/* pickup */ "Pistol Clip",
+/* pickup */ MK23_AMMO_NAME,
 /* width */ 3,
    1,
    NULL,
@@ -2473,7 +2477,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    "models/items/ammo/mag/tris.md2", 0,
    NULL,
 /* icon */ "a_mag",
-/* pickup */ "Machinegun Magazine",
+/* pickup */ MP5_AMMO_NAME,
 /* width */ 3,
    1,
    NULL,
@@ -2496,7 +2500,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    "models/items/ammo/m4/tris.md2", 0,
    NULL,
 /* icon */ "a_m4",
-/* pickup */ "M4 Clip",
+/* pickup */ M4_AMMO_NAME,
 /* width */ 3,
    1,
    NULL,
@@ -2518,7 +2522,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    "models/items/ammo/shells/medium/tris.md2", 0,
    NULL,
 /* icon */ "a_shells",
-/* pickup */ "12 Gauge Shells",
+/* pickup */ SHOTGUN_AMMO_NAME,
 /* width */ 3,
    7,
    NULL,
@@ -2540,7 +2544,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    "models/items/ammo/sniper/tris.md2", 0,
    NULL,
 /* icon */ "a_bullets",
-/* pickup */ "AP Sniper Ammo",
+/* pickup */ SNIPER_AMMO_NAME,
 /* width */ 3,
    10,
    NULL,
@@ -2570,7 +2574,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    0,
    NULL,
    /* icon */ "p_silencer",
-   /* pickup */ "Silencer",
+   /* pickup */ SIL_NAME,
    /* width */ 2,
    60,
    NULL,
@@ -2593,7 +2597,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    0,
    NULL,
 /* icon */ "slippers",
-/* pickup */ "Stealth Slippers",
+/* pickup */ SLIP_NAME,
 /* width */ 2,
    60,
    NULL,
@@ -2616,7 +2620,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    0,
    NULL,
    /* icon */ "p_bandolier",
-   /* pickup */ "Bandolier",
+   /* pickup */ BAND_NAME,
    /* width */ 2,
    60,
    NULL,
@@ -2638,7 +2642,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    0,
    NULL,
    /* icon */ "i_jacketarmor",
-   /* pickup */ "Kevlar Vest",
+   /* pickup */ KEV_NAME,
    /* width */ 2,
    60,
    NULL,
@@ -2660,7 +2664,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    0,
    NULL,
    /* icon */ "p_laser",
-   /* pickup */ "Lasersight",
+   /* pickup */ LASER_NAME,
    /* width */ 2,
    60,
    NULL,
@@ -2733,7 +2737,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    "models/items/silencer/tris.md2", EF_ROTATE,
    NULL,
 /* icon */ "p_silencer",
-/* pickup */ "Silencer",
+/* pickup */ SIL_NAME,
 /* width */ 2,
    60,
    NULL,
@@ -2756,7 +2760,7 @@ world_model_flags int               copied to 'ent->s.effects' (see s.effects fo
    0,
    NULL,
    /* icon */ "p_rebreather",
-   /* pickup */ "Kevlar Helmet",
+   /* pickup */ HELM_NAME,
    /* width */ 2,
    60,
    NULL,

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -806,10 +806,10 @@ extern int stopAP;
 
 extern edict_t *g_edicts;
 
-#define FOFS(x)  (int)&(((edict_t *)0)->x)
-#define STOFS(x) (int)&(((spawn_temp_t *)0)->x)
-#define LLOFS(x) (int)&(((level_locals_t *)0)->x)
-#define CLOFS(x) (int)&(((gclient_t *)0)->x)
+#define FOFS(x)  (ptrdiff_t)&(((edict_t *)0)->x)
+#define STOFS(x) (ptrdiff_t)&(((spawn_temp_t *)0)->x)
+#define LLOFS(x) (ptrdiff_t)&(((level_locals_t *)0)->x)
+#define CLOFS(x) (ptrdiff_t)&(((gclient_t *)0)->x)
 
 #define random()        ((rand () & 0x7fff) / ((float)0x7fff))
 #define crandom()       (2.0 * (random() - 0.5))
@@ -832,7 +832,10 @@ extern cvar_t *limchasecam;
 extern cvar_t *roundlimit;
 extern cvar_t *skipmotd;
 extern cvar_t *nohud;
+extern cvar_t *hud_team_icon;
+extern cvar_t *hud_items_cycle;
 extern cvar_t *noscore;
+extern cvar_t *hud_noscore;
 extern cvar_t *use_newscore;
 extern cvar_t *actionversion;
 extern cvar_t *use_voice;
@@ -871,6 +874,7 @@ extern cvar_t *check_time;
 extern cvar_t *matchmode;
 extern cvar_t *darkmatch;
 extern cvar_t *day_cycle;	// If darkmatch is on, this value is the nr of seconds between each interval (day, dusk, night, dawn)
+extern cvar_t *use_flashlight;  // Allow flashlight when not darkmatch?
 
 extern cvar_t *hearall;		// used in match mode
 extern cvar_t *deadtalk;
@@ -947,6 +951,7 @@ extern cvar_t *knifelimit;
 extern cvar_t *tgren;
 extern cvar_t *allweapon;
 extern cvar_t *allitem;
+extern cvar_t *allow_hoarding; // Allow carrying multiple of the same special item or unique weapon.
 
 extern cvar_t *stats_endmap; // If on (1), show the accuracy/etc stats at the end of a map
 extern cvar_t *stats_afterround; // TNG Stats, collect stats between rounds
@@ -965,8 +970,12 @@ extern cvar_t *use_ghosts;
 
 // zucc from action
 extern cvar_t *sv_shelloff;
+extern cvar_t *shelllimit;
+extern cvar_t *shelllife;
 extern cvar_t *splatlimit;
 extern cvar_t *bholelimit;
+extern cvar_t *splatlife;
+extern cvar_t *bholelife;
 
 #define world   (&g_edicts[0])
 
@@ -1054,7 +1063,7 @@ void Touch_Item (edict_t * ent, edict_t * other, cplane_t * plane,
 qboolean KillBox (edict_t * ent);
 void G_ProjectSource (vec3_t point, vec3_t distance, vec3_t forward,
 		      vec3_t right, vec3_t result);
-edict_t *G_Find (edict_t * from, int fieldofs, char *match);
+edict_t *G_Find (edict_t * from, ptrdiff_t fieldofs, char *match);
 edict_t *findradius (edict_t * from, vec3_t org, float rad);
 edict_t *G_PickTarget (char *targetname);
 void G_UseTargets (edict_t * ent, edict_t * activator);
@@ -1069,7 +1078,8 @@ void G_TouchSolids (edict_t * ent);
 
 char *G_CopyString (char *in);
 
-//float *tv (float x, float y, float z);
+// FIXME: re-enabled for bots
+float *tv (float x, float y, float z);
 char *vtos (vec3_t v);
 
 float vectoyaw (vec3_t vec);
@@ -1947,6 +1957,12 @@ void AddSplat (edict_t * self, vec3_t point, trace_t * tr);
 #define KNIFE_NAME   "Combat Knife"
 #define GRENADE_NAME "M26 Fragmentation Grenade"
 
+#define MK23_AMMO_NAME    "Pistol Magazine"
+#define MP5_AMMO_NAME     "MP5 Magazine"
+#define M4_AMMO_NAME      "M4 Magazine"
+#define SHOTGUN_AMMO_NAME "12 Gauge Shells"
+#define SNIPER_AMMO_NAME  "AP Sniper Ammo"
+
 #define SIL_NAME     "Silencer"
 #define SLIP_NAME    "Stealth Slippers"
 #define BAND_NAME    "Bandolier"
@@ -2051,7 +2067,7 @@ extern int tnums[ITEM_COUNT];
 #define BANDAGE_TIME    27	// 10 = 1 second
 #define BLEED_TIME      10	// 10 = 1 second is time for losing 1 health at slowest bleed rate
 // Igor's back in Time to hard grenades :-)
-//#define GRENADE_DAMRAD  170
+#define GRENADE_DAMRAD_CLASSIC  170
 #define GRENADE_DAMRAD  250
 
 //AQ2:TNG - Slicer New location support

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -1049,7 +1049,7 @@ void G_RunFrame (void)
 				// TNG Stats End
 
 				ClientBeginServerFrame (ent);
-                                continue;
+				continue;
 			}
 
 			G_RunEntity (ent);

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -299,7 +299,10 @@ cvar_t *limchasecam;
 cvar_t *roundlimit;
 cvar_t *skipmotd;
 cvar_t *nohud;
+cvar_t *hud_team_icon;
+cvar_t *hud_items_cycle;
 cvar_t *noscore;
+cvar_t *hud_noscore;
 cvar_t *use_newscore;
 cvar_t *actionversion;
 cvar_t *needpass;
@@ -366,9 +369,14 @@ cvar_t *flashtime;*/
 //SLIC2
 cvar_t *allweapon;
 cvar_t *allitem;
+cvar_t *allow_hoarding;
 cvar_t *sv_shelloff;
+cvar_t *shelllimit;
+cvar_t *shelllife;
 cvar_t *bholelimit;
 cvar_t *splatlimit;
+cvar_t *bholelife;
+cvar_t *splatlife;
 cvar_t *check_time;		// Time to wait before checks start ?
 cvar_t *video_check;
 cvar_t *video_checktime;
@@ -384,6 +392,7 @@ cvar_t *itm_flags;		// Item Banning
 cvar_t *matchmode;
 cvar_t *darkmatch;		// Darkmatch
 cvar_t *day_cycle;		// If darkmatch is on, this value is the nr of seconds between each interval (day, dusk, night, dawn)
+cvar_t *use_flashlight;         // Allow flashlight when not darkmatch?
 cvar_t *hearall;		// used for matchmode
 cvar_t *deadtalk;
 
@@ -601,7 +610,6 @@ void EndDMLevel (void)
 	char ltm[64] = "\0";
 	struct tm *now;
 	time_t tnow;
-
 
 	tnow = time ((time_t *) 0);
 	now = localtime (&tnow);
@@ -1041,7 +1049,7 @@ void G_RunFrame (void)
 				// TNG Stats End
 
 				ClientBeginServerFrame (ent);
-				continue;
+                                continue;
 			}
 
 			G_RunEntity (ent);

--- a/source/g_phys.c
+++ b/source/g_phys.c
@@ -864,7 +864,8 @@ SV_Physics_Toss (edict_t * ent)
     {
       if (!ent->splatted)
 	{
-	  AddSplat (ent->owner, ent->s.origin, &trace);
+          if ( trace.surface && (!( trace.ent && trace.ent->takedamage )) && ! (trace.surface->flags & SURF_SKY) )
+	    AddSplat (ent->owner, ent->s.origin, &trace);
 	  ent->splatted = true;
 	}
 

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -521,6 +521,8 @@ void InitGame (void)
 		gi.cvar_forceset("actionmaps", "0");
 	}
 	nohud = gi.cvar ("nohud", "0", CVAR_LATCH);
+	hud_team_icon = gi.cvar ("hud_team_icon", "1", 0);
+	hud_items_cycle = gi.cvar ("hud_items_cycle", "20", 0);
 	roundlimit = gi.cvar ("roundlimit", "0", CVAR_SERVERINFO);
 	limchasecam = gi.cvar ("limchasecam", "0", CVAR_LATCH);
 	skipmotd = gi.cvar ("skipmotd", "0", 0);
@@ -529,7 +531,8 @@ void InitGame (void)
 	twbanrounds = gi.cvar ("twbanrounds", "2", 0);
 	tkbanrounds = gi.cvar ("tkbanrounds", "2", 0);
 	noscore = gi.cvar ("noscore", "0", CVAR_LATCH);	// Was serverinfo
-	use_newscore = gi.cvar ("use_newscore", "1", 0);
+	hud_noscore = gi.cvar ("hud_noscore", "1", CVAR_LATCH); // Hide score from HUD in teamplay.
+	use_newscore = gi.cvar ("use_newscore", "0", 0);
 	actionversion =
 	gi.cvar ("actionversion", "none set", CVAR_SERVERINFO | CVAR_LATCH);
 	gi.cvar_set ("actionversion", ACTION_VERSION);
@@ -631,6 +634,7 @@ void InitGame (void)
 	knifelimit = gi.cvar ("knifelimit", "40", 0);
 	allweapon = gi.cvar ("allweapon", "0", CVAR_SERVERINFO);
 	allitem = gi.cvar ("allitem", "0", CVAR_SERVERINFO);
+	allow_hoarding = gi.cvar ("allow_hoarding", "0", CVAR_LATCH);
 	tgren = gi.cvar ("tgren", "0", CVAR_SERVERINFO);
 	//SLIC2
 	/*flashgren = gi.cvar ("flashgren", "1", 0);
@@ -638,10 +642,15 @@ void InitGame (void)
 	flashtime = gi.cvar ("flashtime", "100", 0);*/
 	//SLIC2
 	sv_shelloff = gi.cvar ("shelloff", "1", 0);
+	shelllimit = gi.cvar ("shelllimit", "24", 0);
+	shelllife = gi.cvar ("shelllife", "1.2", 0);
 	bholelimit = gi.cvar ("bholelimit", "0", 0);
 	splatlimit = gi.cvar ("splatlimit", "0", 0);
+	bholelife = gi.cvar ("bholelife", "20", 0);
+	splatlife = gi.cvar ("splatlife", "25", 0);
 	darkmatch = gi.cvar ("darkmatch", "0", CVAR_LATCH);	// Darkmatch
 	day_cycle = gi.cvar ("day_cycle", "10", 0);	// Darkmatch cycle time.
+	use_flashlight = gi.cvar ("use_flashlight", "0", CVAR_SERVERINFO);
 	use_classic = gi.cvar ("use_classic", "0", CVAR_SERVERINFO);	// Reset Spread and Grenade Strength to 1.52
 
 	CGF_SFX_InstallGlassSupport ();	// william for CGF (glass fx)

--- a/source/g_spawn.c
+++ b/source/g_spawn.c
@@ -1361,8 +1361,6 @@ char *dm_noscore_statusbar = ""
 "yt 2 "
 "num 3 14"
 */
-// team icon
-  "if 23 xl 0 yb -32 pic 23 endif "
 ;
 // END FB
 

--- a/source/g_spawn.c
+++ b/source/g_spawn.c
@@ -154,6 +154,8 @@
 
 #include "g_local.h"
 
+void PrecacheItems();
+
 typedef struct
 {
   char *name;
@@ -1200,9 +1202,13 @@ xl < value > xr < value > yb < value > yt < value > xv < value > yv < value >
     "yb -58 " "string \"Viewing\" " "xv 64 " "stat_string 21 " "endif ";
 
 
-char *dm_statusbar = "yb     -24 "
+char *dm_statusbar = ""
+// team icon
+  "if 23 xl 0 yb -32 pic 23 endif "
+// standard bottom icons
+  "yb     -24 "
 // health
-  "xv     0 " "hnum " "xv     50 " "pic 0 "
+  "if 0 " "xv     0 " "hnum " "xv     50 " "pic 0 " "endif "
 // ammo
   "if 2 "
   "       xv      100 "
@@ -1271,14 +1277,17 @@ char *dm_statusbar = "yb     -24 "
   "       yb      0 "
   "       xv      0 " "       yv      0 " "       pic 18 " "endif "
 //  frags
-  "xr     -50 " "yt 2 " "num 3 14";
-
-
+  "xr     -50 " "yt 2 " "num 3 14"
+;
 
 /* DM status bar for teamplay without individual scores -FB: */
-char *dm_noscore_statusbar = "yb     -24 "
+char *dm_noscore_statusbar = ""
+// team icon
+  "if 23 xl 0 yb -32 pic 23 endif "
+// standard bottom icons
+  "yb     -24 "
 // health
-  "xv     0 " "hnum " "xv     50 " "pic 0 "
+  "if 0 " "xv     0 " "hnum " "xv     50 " "pic 0 " "endif "
 // ammo
   "if 2 "
   "       xv      100 "
@@ -1352,7 +1361,9 @@ char *dm_noscore_statusbar = "yb     -24 "
 "yt 2 "
 "num 3 14"
 */
- ;
+// team icon
+  "if 23 xl 0 yb -32 pic 23 endif "
+;
 // END FB
 
 char *ctf_statusbar = "yb     -24 "
@@ -1514,7 +1525,7 @@ void SP_worldspawn (edict_t * ent)
 			gi.imageindex ("i_ctf1t");
 			gi.imageindex ("i_ctf2t");
 		}
-		else if (noscore->value && teamplay->value)
+		else if ((noscore->value || hud_noscore->value) && teamplay->value)
 		{
 			gi.configstring (CS_STATUSBAR, dm_noscore_statusbar);
 		}

--- a/source/g_svcmds.c
+++ b/source/g_svcmds.c
@@ -501,6 +501,50 @@ void SVCmd_SoftQuit_f (void)
 	softquit = 1;
 }
 
+void SVCmd_Slap_f (void)
+{
+	if( gi.argc() < 3 )
+	{
+		gi.cprintf( NULL, PRINT_HIGH, "Usage: sv slap <name> [<damage>] [<power>]\n" );
+		return;
+	}
+	if( lights_camera_action )
+	{
+		gi.cprintf( NULL, PRINT_HIGH, "Can't slap yet!\n" );
+		return;
+	}
+
+	const char *name = gi.argv(2);
+	size_t name_len = strlen(name);
+	int damage = atoi(gi.argv(3));
+	float power = (gi.argc() >= 5) ? atof(gi.argv(4)) : 100.f;
+	vec3_t slap_dir = {0.f,0.f,1.f}, slap_normal = {0.f,0.f,-1.f};
+	qboolean found_victim = false;
+
+	size_t i;
+	for( i = 0; i < maxclients->value ; i ++ )
+	{
+		edict_t *ent = g_edicts + i + 1;
+		if( ent->inuse && (strncasecmp( ent->client->pers.netname, name, name_len ) == 0) )
+		{
+			found_victim = true;
+			if( (ent->deadflag != DEAD_DEAD) && (ent->solid != SOLID_NOT) )
+			{
+				slap_dir[ 0 ] = crandom() * 0.5f;
+				slap_dir[ 1 ] = crandom() * 0.5f;
+				T_Damage( ent, world, world, slap_dir, ent->s.origin, slap_normal, damage, power, 0, MOD_KICK );
+				gi.sound( ent, CHAN_WEAPON, gi.soundindex("weapons/kick.wav"), 1, ATTN_NORM, 0 );
+				gi.bprintf( PRINT_HIGH, "Admin slapped %s for %i damage.\n", ent->client->pers.netname, damage );
+			}
+			else
+				gi.cprintf( NULL, PRINT_HIGH, "%s is already dead.\n", ent->client->pers.netname );
+		}
+	}
+
+	if( ! found_victim )
+		gi.cprintf( NULL, PRINT_HIGH, "Couldn't find %s to slap.\n", name );
+}
+
 /*
 =================
 ServerCommand
@@ -541,6 +585,23 @@ void ServerCommand (void)
 		SVCmd_ResetScores_f ();
 	else if (Q_stricmp (cmd, "softquit") == 0)
 		SVCmd_SoftQuit_f ();
+	else if (Q_stricmp (cmd, "slap") == 0)
+		SVCmd_Slap_f ();
+	else if (Q_stricmp (cmd, "showangles") == 0)
+	{
+		size_t i;
+		for( i = 0; i < maxclients->value ; i ++ )
+		{
+			edict_t *ent = g_edicts + i + 1;
+			if( ent->inuse )
+			{
+				gi.cprintf( NULL, PRINT_HIGH, "\n%-12.12s: resp.cmd_angles:       %5.1f, %6.1f, %5.1f\n", ent->client->pers.netname, ent->client->resp.cmd_angles[0], ent->client->resp.cmd_angles[1], ent->client->resp.cmd_angles[2] );
+				gi.cprintf( NULL, PRINT_HIGH,   "%-12.12s: v_angle:               %5.1f, %6.1f, %5.1f\n", ent->client->pers.netname, ent->client->v_angle[0], ent->client->v_angle[1], ent->client->v_angle[2] );
+				gi.cprintf( NULL, PRINT_HIGH,   "%-12.12s: ps.viewangles:         %5.1f, %6.1f, %5.1f\n", ent->client->pers.netname, ent->client->ps.viewangles[0], ent->client->ps.viewangles[1], ent->client->ps.viewangles[2] );
+				gi.cprintf( NULL, PRINT_HIGH,   "%-12.12s: ps.pmove.delta_angles: %5.1f, %6.1f, %5.1f\n", ent->client->pers.netname, SHORT2ANGLE(ent->client->ps.pmove.delta_angles[0]), SHORT2ANGLE(ent->client->ps.pmove.delta_angles[1]), SHORT2ANGLE(ent->client->ps.pmove.delta_angles[2]) );
+			}
+		}
+	}
 	else
 		gi.cprintf (NULL, PRINT_HIGH, "Unknown server command \"%s\"\n", cmd);
 }

--- a/source/g_target.c
+++ b/source/g_target.c
@@ -443,7 +443,7 @@ void
 use_target_blaster (edict_t * self, edict_t * other, edict_t * activator)
 {
   /*
-  int effect;
+  int effect;  // FIXME: This was set but never used.
 
   if (self->spawnflags & 2)
     effect = 0;
@@ -454,7 +454,7 @@ use_target_blaster (edict_t * self, edict_t * other, edict_t * activator)
   */
 
   fire_blaster (self, self->s.origin, self->movedir, self->dmg, self->speed,
-		EF_BLASTER, MOD_TARGET_BLASTER);
+		EF_BLASTER, MOD_TARGET_BLASTER);  // FIXME: Should this use effect instead of EF_BLASTER?
   gi.sound (self, CHAN_VOICE, self->noise_index, 1, ATTN_NORM, 0);
 }
 

--- a/source/g_target.c
+++ b/source/g_target.c
@@ -442,6 +442,7 @@ speed   default is 1000
 void
 use_target_blaster (edict_t * self, edict_t * other, edict_t * activator)
 {
+  /*
   int effect;
 
   if (self->spawnflags & 2)
@@ -450,6 +451,7 @@ use_target_blaster (edict_t * self, edict_t * other, edict_t * activator)
     effect = EF_HYPERBLASTER;
   else
     effect = EF_BLASTER;
+  */
 
   fire_blaster (self, self->s.origin, self->movedir, self->dmg, self->speed,
 		EF_BLASTER, MOD_TARGET_BLASTER);

--- a/source/g_utils.c
+++ b/source/g_utils.c
@@ -37,7 +37,7 @@ NULL will be returned if the end of the list is reached.
 
 =============
 */
-edict_t *G_Find (edict_t * from, int fieldofs, char *match)
+edict_t *G_Find (edict_t * from, ptrdiff_t fieldofs, char *match)
 {
 	char *s;
 
@@ -262,7 +262,8 @@ This is just a convenience function
 for making temporary vectors for function calls
 =============
 */
-/*float *tv (float x, float y, float z)
+// FIXME: re-enabled for bots
+float *tv (float x, float y, float z)
 {
 	static int index;
 	static vec3_t vecs[8];
@@ -278,7 +279,7 @@ for making temporary vectors for function calls
 	v[2] = z;
 
 	return v;
-}*/
+}
 
 
 /*

--- a/source/g_xmisc.c
+++ b/source/g_xmisc.c
@@ -134,7 +134,7 @@ void punch_attack(edict_t * ent)
 //PRINT_CHAT - got it by Riviera
 char *strtostr2(char *s)
 {
-	unsigned char *p = s;
+	unsigned char *p = (unsigned char*) s;
 
 	while (*p) {
 		if ((*p >= 0x1b && *p <= 0x7f)
@@ -143,7 +143,7 @@ char *strtostr2(char *s)
 
 		p++;
 	}
-	return (char *) s;
+	return s;
 }
 
 //plays a random sound/insane sound, insane1-9.wav
@@ -163,7 +163,7 @@ void PlayRandomInsaneSound(edict_t * ent)
 //returns next client entity that is within cube
 edict_t *findblock(edict_t * from, vec3_t p1, vec3_t p2)
 {
-	vec3_t eorg;
+	vec3_t eorg = {0.f,0.f,0.f};
 	int j;
 
 	if (!from)

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -320,6 +320,8 @@
 #include "m_player.h"
 #include "cgf_sfx_glass.h"
 
+void Cmd_Inven_f( edict_t *ent );
+
 void ClientUserinfoChanged(edict_t * ent, char *userinfo);
 void ClientDisconnect(edict_t * ent);
 void SP_misc_teleporter_dest(edict_t * ent);
@@ -1862,11 +1864,13 @@ void InitClientResp(gclient_t * client)
 	gitem_t *weapon = client->resp.weapon;
 	qboolean menu_shown = client->resp.menu_shown;
 	qboolean dm_selected = client->resp.dm_selected;
+	char *mapvote = client->resp.mapvote;
 
 	memset(&client->resp, 0, sizeof(client->resp));
 	client->resp.team = team;
 	client->resp.enterframe = level.framenum;
 	client->resp.coop_respawn = client->pers;
+	client->resp.mapvote = mapvote;
 
 	if (!dm_choose->value && !warmup->value) {
 		if ((int) wp_flags->value & WPF_MP5) {
@@ -2765,7 +2769,7 @@ void PutClientInServer(edict_t * ent)
 	client->team_wounds = save_team_wounds;
 	client->team_kills = save_team_kills;
 
-	if (save_ipaddr && client->ipaddr)
+	if (client->ipaddr)
 		strcpy(client->ipaddr, save_ipaddr);
 //FF
 	if (client->pers.health <= 0)
@@ -2890,7 +2894,7 @@ void PutClientInServer(edict_t * ent)
 	gi.linkentity(ent);
 
 	//zucc give some ammo
-	//item = FindItem("Pistol Clip");     
+	//item = FindItem("Pistol Magazine");
 	// Add_Ammo(ent,item,1);
 	client->mk23_max = 12;
 	client->mp5_max = 30;
@@ -3267,6 +3271,7 @@ qboolean ClientConnect(edict_t * ent, char *userinfo)
 	ResetKills(ent);
 
 	// We're not going to attempt to support reconnection...
+	// FIXME: why is this here and what does it do? doesn't work with bots! -hifi
 	if (ent->inuse == true) {
 		ClientDisconnect(ent);
 		ent->inuse = false;

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2894,7 +2894,7 @@ void PutClientInServer(edict_t * ent)
 	gi.linkentity(ent);
 
 	//zucc give some ammo
-	//item = FindItem("Pistol Magazine");
+	//item = FindItem(MK23_AMMO_NAME);
 	// Add_Ammo(ent,item,1);
 	client->mk23_max = 12;
 	client->mp5_max = 30;

--- a/source/p_hud.c
+++ b/source/p_hud.c
@@ -296,8 +296,7 @@ void DeathmatchScoreboardMessage (edict_t * ent, edict_t * killer)
 		cl = &game.clients[sorted[i]];
 		cl_ent = g_edicts + 1 + sorted[i];
 
-		//picnum = gi.imageindex ("i_fixme");
-		gi.imageindex ("i_fixme");  // FIXME: What is this for?  The return value was never used.
+		//picnum = gi.imageindex ("i_fixme");  // FIXME: What is this for?
 		x = (i >= 6) ? 160 : 0;
 		y = 32 + 32 * (i % 6);
 

--- a/source/p_hud.c
+++ b/source/p_hud.c
@@ -721,27 +721,28 @@ void G_SetStats (edict_t * ent)
 		ent->client->ps.stats[STAT_FRAGS] = ent->client->resp.score;
 
 		//
-		// help icon / current weapon if not shown
+		// bandaging icon / current weapon if not shown
 		//
-		if (ent->client->resp.helpchanged && (level.framenum & 8))
-			ent->client->ps.stats[STAT_HELPICON] = gi.imageindex ("i_help");
-		else if ((ent->client->pers.hand == CENTER_HANDED || ent->client->ps.fov > 91)
-			&& ent->client->pers.weapon && ent->deadflag != DEAD_DEAD && ent->solid != SOLID_NOT)
+		// TNG: Show health icon when bandaging (thanks to Dome for this code)
+		if (ent->client->weaponstate == WEAPON_BANDAGING || ent->client->bandaging || ent->client->bandage_stopped)
+			ent->client->ps.stats[STAT_HELPICON] = gi.imageindex ("i_health");
+		else if ((ent->client->pers.hand == CENTER_HANDED || ent->client->ps.fov > 91) && ent->client->pers.weapon)
 			ent->client->ps.stats[STAT_HELPICON] = gi.imageindex (ent->client->pers.weapon->icon);
 		else
 			ent->client->ps.stats[STAT_HELPICON] = 0;
 
-		// TNG: Show health icon when bandaging (thanks to Dome for this code)
-		if (ent->client->weaponstate == WEAPON_BANDAGING || ent->client->bandaging || ent->client->bandage_stopped)
-			ent->client->ps.stats[STAT_HELPICON] = gi.imageindex ("i_health");
-
-		// Hide health, ammo, and weapon when spectating.
+		// Hide health, ammo, weapon, and bandaging state when free spectating.
 		if( /* (! old_spectator_hud->value) && */ (ent->health > 0) && ((ent->deadflag == DEAD_DEAD) || (ent->solid == SOLID_NOT)) )
 		{
 			ent->client->ps.stats[STAT_HEALTH_ICON] = 0;
 			ent->client->ps.stats[STAT_AMMO_ICON] = 0;
 			ent->client->ps.stats[STAT_SELECTED_ICON] = 0;
+			ent->client->ps.stats[STAT_HELPICON] = 0;
 		}
+
+		// Help icon doesn't depend on whether you're alive or spectating.
+		if (ent->client->resp.helpchanged && (level.framenum & 8))
+			ent->client->ps.stats[STAT_HELPICON] = gi.imageindex ("i_help");
 
 		// Team icon.
 		if( teamplay->value && ! ctf->value )

--- a/source/p_hud.c
+++ b/source/p_hud.c
@@ -237,7 +237,7 @@ void DeathmatchScoreboardMessage (edict_t * ent, edict_t * killer)
 	int sorted[MAX_CLIENTS];
 	int sortedscores[MAX_CLIENTS];
 	int score, total;
-	//int picnum;
+	//int picnum;  // FIXME: This was set but never used.
 	int x, y;
 	gclient_t *cl;
 	edict_t *cl_ent;
@@ -297,7 +297,7 @@ void DeathmatchScoreboardMessage (edict_t * ent, edict_t * killer)
 		cl_ent = g_edicts + 1 + sorted[i];
 
 		//picnum = gi.imageindex ("i_fixme");
-		gi.imageindex ("i_fixme");
+		gi.imageindex ("i_fixme");  // FIXME: What is this for?  The return value was never used.
 		x = (i >= 6) ? 160 : 0;
 		y = 32 + 32 * (i % 6);
 

--- a/source/p_view.c
+++ b/source/p_view.c
@@ -1404,19 +1404,17 @@ void ClientEndServerFrame (edict_t * ent)
 		}
 
 		//
-		// help icon / current weapon if not shown
+		// help icon / bandaging icon / current weapon if not shown
 		//
 		if (e->client->resp.helpchanged && (level.framenum & 8))
 			e->client->ps.stats[STAT_HELPICON] = gi.imageindex ("i_help");
-		else if ((e->client->pers.hand == CENTER_HANDED || e->client->ps.fov > 91)
-			&& ent->client->pers.weapon && e->client->chase_mode == 2)
+		// TNG: Show health icon when bandaging (thanks to Dome for this code)
+		else if (ent->client->weaponstate == WEAPON_BANDAGING || ent->client->bandaging || ent->client->bandage_stopped)
+			e->client->ps.stats[STAT_HELPICON] = gi.imageindex ("i_health");
+		else if ((e->client->pers.hand == CENTER_HANDED || e->client->ps.fov > 91) && ent->client->pers.weapon && e->client->chase_mode == 2)
 			e->client->ps.stats[STAT_HELPICON] = gi.imageindex (ent->client->pers.weapon->icon);
 		else
 			e->client->ps.stats[STAT_HELPICON] = 0;
-
-		// TNG: Show health icon when bandaging (thanks to Dome for this code)
-		if (ent->client->weaponstate == WEAPON_BANDAGING || ent->client->bandaging || ent->client->bandage_stopped)
-			e->client->ps.stats[STAT_HELPICON] = gi.imageindex ("i_health");
 
 	//FB                e->client->ps.stats[STAT_LAYOUTS] = 1;
 	//FB                break;

--- a/source/p_weapon.c
+++ b/source/p_weapon.c
@@ -309,6 +309,8 @@ qboolean Pickup_Weapon (edict_t * ent, edict_t * other)
 	{
 		if (other->client->unique_weapon_total >= unique_weapons->value + band)
 			return false;		// we can't get it
+		if ((! allow_hoarding->value) && other->client->pers.inventory[index])
+			return false;		// we already have one
 
 		other->client->pers.inventory[index]++;
 		other->client->unique_weapon_total++;
@@ -322,6 +324,8 @@ qboolean Pickup_Weapon (edict_t * ent, edict_t * other)
 	{
 		if (other->client->unique_weapon_total >= unique_weapons->value + band)
 			return false;		// we can't get it
+		if ((! allow_hoarding->value) && other->client->pers.inventory[index])
+			return false;		// we already have one
 
 		other->client->pers.inventory[index]++;
 		other->client->unique_weapon_total++;
@@ -335,6 +339,8 @@ qboolean Pickup_Weapon (edict_t * ent, edict_t * other)
 	{
 		if (other->client->unique_weapon_total >= unique_weapons->value + band)
 			return false;		// we can't get it
+		if ((! allow_hoarding->value) && other->client->pers.inventory[index])
+			return false;		// we already have one
 
 		other->client->pers.inventory[index]++;
 		other->client->unique_weapon_total++;
@@ -363,6 +369,8 @@ qboolean Pickup_Weapon (edict_t * ent, edict_t * other)
 	{
 		if (other->client->unique_weapon_total >= unique_weapons->value + band)
 			return false;		// we can't get it
+		if ((! allow_hoarding->value) && other->client->pers.inventory[index])
+			return false;		// we already have one
 
 		other->client->pers.inventory[index]++;
 		other->client->unique_weapon_total++;
@@ -383,6 +391,8 @@ qboolean Pickup_Weapon (edict_t * ent, edict_t * other)
 	{
 		if (other->client->unique_weapon_total >= unique_weapons->value + band)
 			return false;		// we can't get it
+		if ((! allow_hoarding->value) && other->client->pers.inventory[index])
+			return false;		// we already have one
 
 		other->client->pers.inventory[index]++;
 		other->client->unique_weapon_total++;
@@ -1108,7 +1118,7 @@ void Drop_Weapon (edict_t * ent, gitem_t * item)
 
 				// Reset Grenade Damage to 1.52 when requested:
 				if (use_classic->value)
-					damage = 170;
+					damage = GRENADE_DAMRAD_CLASSIC;
 				else
 					damage = GRENADE_DAMRAD;
 				
@@ -2280,9 +2290,9 @@ weapon_grenade_fire (edict_t * ent, qboolean held)
   int damage = 125;
   float timer;
   int speed;
-  float radius;
+  //float radius;
 
-  radius = damage + 40;
+  //radius = damage + 40;
   if (is_quad)
     damage *= 4;
 
@@ -2298,7 +2308,7 @@ weapon_grenade_fire (edict_t * ent, qboolean held)
 
   // Reset Grenade Damage to 1.52 when requested:
   if (use_classic->value)
-    fire_grenade2 (ent, start, forward, 170, speed, timer, 170 * 2, held);
+    fire_grenade2 (ent, start, forward, GRENADE_DAMRAD_CLASSIC, speed, timer, GRENADE_DAMRAD_CLASSIC * 2, held);
   else
     fire_grenade2 (ent, start, forward, GRENADE_DAMRAD, speed, timer,
 		   GRENADE_DAMRAD * 2, held);
@@ -3374,13 +3384,6 @@ void MP5_Fire (edict_t * ent)
 	else
 		height = 0;
 
-
-	// If requested, use 1.52 spread
-	if (use_classic->value)
-		spread = 250;
-	else
-		spread = MP5_SPREAD;
-
 	//If the user isn't pressing the attack button, advance the frame and go away....
 	if (!(ent->client->buttons & BUTTON_ATTACK) && !(ent->client->burst))
 	{
@@ -3936,7 +3939,7 @@ void Sniper_Fire (edict_t * ent)
 	//int i;
 	vec3_t start;
 	vec3_t forward, right;
-	vec3_t angles;
+	//vec3_t angles;
 	int damage = 250;
 	int kick = 200;
 	vec3_t offset;
@@ -4019,7 +4022,7 @@ void Sniper_Fire (edict_t * ent)
 	VectorClear(ent->client->kick_angles);
 
 	// get start / end positions
-	VectorAdd (ent->client->v_angle, ent->client->kick_angles, angles);
+	//VectorAdd (ent->client->v_angle, ent->client->kick_angles, angles);
 	AngleVectors (ent->client->v_angle, forward, right, NULL);
 	VectorSet (offset, 0, 0, ent->viewheight - 0);
 
@@ -4095,12 +4098,6 @@ void Dual_Fire (edict_t * ent)
 		height = 8;
 	else
 		height = 0;
-
-	// Reset spread to 1.52 when requested
-	if (use_classic->value)
-		spread = 300;
-	else
-		spread = DUAL_SPREAD;
 
 	spread = AdjustSpread (ent, spread);
 
@@ -4817,7 +4814,7 @@ void gas_fire (edict_t * ent)
 
 	// Reset Grenade Damage to 1.52 when requested:
 	if (use_classic->value)
-		damage = 170;
+		damage = GRENADE_DAMRAD_CLASSIC;
 	else
 		damage = GRENADE_DAMRAD;
 
@@ -5042,7 +5039,7 @@ void Weapon_Gas (edict_t * ent)
 
 			// Reset Grenade Damage to 1.52 when requested:
 			if (use_classic->value)
-				damage = 170;
+				damage = GRENADE_DAMRAD_CLASSIC;
 			else
 				damage = GRENADE_DAMRAD;
 			

--- a/source/p_weapon.c
+++ b/source/p_weapon.c
@@ -2290,9 +2290,9 @@ weapon_grenade_fire (edict_t * ent, qboolean held)
   int damage = 125;
   float timer;
   int speed;
-  //float radius;
+  //float radius;  // FIXME: This was set but never used.
 
-  //radius = damage + 40;
+  //radius = damage + 40;  // FIXME: Should this be used somewhere?
   if (is_quad)
     damage *= 4;
 
@@ -3936,10 +3936,10 @@ void Weapon_HC (edict_t * ent)
 
 void Sniper_Fire (edict_t * ent)
 {
-	//int i;
+	//int i;  // FIXME: Should this be used somewhere?
 	vec3_t start;
 	vec3_t forward, right;
-	//vec3_t angles;
+	//vec3_t angles;  // FIXME: This was set below, but never used.
 	int damage = 250;
 	int kick = 200;
 	vec3_t offset;
@@ -4022,8 +4022,8 @@ void Sniper_Fire (edict_t * ent)
 	VectorClear(ent->client->kick_angles);
 
 	// get start / end positions
-	//VectorAdd (ent->client->v_angle, ent->client->kick_angles, angles);
-	AngleVectors (ent->client->v_angle, forward, right, NULL);
+	//VectorAdd (ent->client->v_angle, ent->client->kick_angles, angles);  // FIXME: Should this be used?
+	AngleVectors (ent->client->v_angle, forward, right, NULL);  // FIXME: Should this be angles instead of v_angle?
 	VectorSet (offset, 0, 0, ent->viewheight - 0);
 
 	P_ProjectSource (ent->client, ent->s.origin, offset, forward, right, start);

--- a/source/q_shared.h
+++ b/source/q_shared.h
@@ -69,14 +69,15 @@
 
 //==============================================
 #ifdef _WIN32
+#ifdef _MSC_VER
 // unknown pragmas are SUPPOSED to be ignored, but....
 #pragma warning(disable : 4244)	// MIPS
 #pragma warning(disable : 4136)	// X86
 #pragma warning(disable : 4051)	// ALPHA
 #pragma warning(disable : 4018)	// signed/unsigned mismatch
 #pragma warning(disable : 4305)	// truncation from const double to float
-
-#pragma warning(disable : 4996)		// deprecated functions
+#pragma warning(disable : 4996)	// deprecated functions
+#endif
 
 # define HAVE___INLINE
 # define HAVE__SNPRINTF
@@ -1403,9 +1404,7 @@ typedef struct
   int rdflags;			// refdef flags
 
   short stats[MAX_STATS];	// fast status bar updates
-
 }
 player_state_t;
 
 #endif
-

--- a/source/tng_flashlight.c
+++ b/source/tng_flashlight.c
@@ -21,18 +21,18 @@ void FL_make (edict_t * self)
 		return;
 	}
 
-	gi.sound (self, CHAN_VOICE, gi.soundindex ("misc/flashlight.wav"), 1,
-	ATTN_NORM, 0);
-
 	if (self->flashlight)
 	{
 		G_FreeEdict (self->flashlight);
 		self->flashlight = NULL;
+		gi.sound (self, CHAN_VOICE, gi.soundindex ("misc/flashlight.wav"), 1, ATTN_NORM, 0);
 		return;
 	}
 
 	if (!(darkmatch->value || use_flashlight->value))
 		return;
+
+	gi.sound (self, CHAN_VOICE, gi.soundindex ("misc/flashlight.wav"), 1, ATTN_NORM, 0);
 
 	AngleVectors (self->client->v_angle, forward, right, NULL);
 

--- a/source/tng_flashlight.c
+++ b/source/tng_flashlight.c
@@ -11,9 +11,6 @@ void FL_make (edict_t * self)
 {
 	vec3_t start, forward, right, end;
 
-	if (!darkmatch->value)
-		return;
-
 	if ((self->deadflag == DEAD_DEAD) || (self->solid == SOLID_NOT))
 	{
 		if (self->flashlight)
@@ -33,6 +30,9 @@ void FL_make (edict_t * self)
 		self->flashlight = NULL;
 		return;
 	}
+
+	if (!(darkmatch->value || use_flashlight->value))
+		return;
 
 	AngleVectors (self->client->v_angle, forward, right, NULL);
 


### PR DESCRIPTION
Hey hifi, here are all the non-bot changes I've made for my AQ2-TNG server (which runs on the 'bots' branch).  Since it's my first contribution to the master branch, you'll probably want to check the changes.txt (modified in commit b153572) and see if you think these are all suitable for the default server code.

The most important change, in my opinion, was getting it to build without warnings using gcc -Wall; you never know when undefined behavior will to creep in, especially with optimizations and strict aliasing.

The most noticeable change is the fact that the default teamplay HUD now has your team icon in the bottom left (sometimes I need a reminder) and does not show your individual score in the top right; both of these have configurable server cvars.

The most game-changing thing is probably the fact that laser sights no longer appear on sky textures, which is not configurable via cvar (but I could add one if you'd like).

By the way, I noticed on the old aq2-tng.sourceforge.net page that it mentioned being close to a 2.9 release back in December 2003; do you know if there's a feature roadmap for that version?  It'd be great to help make that milestone a reality, more than a decade later.  :¬)