### PR TITLE
Fixed tequila/rooftops bugs. Credit knocking into pits/lava. Minor decal improvements.

### DIFF
--- a/source/a_game.c
+++ b/source/a_game.c
@@ -579,7 +579,10 @@ void BlooderDie(edict_t * self)
 
 void BlooderTouch(edict_t * self, edict_t * other, cplane_t * plane, csurface_t * surf)
 {
-	G_FreeEdict(self);
+	if( (other == self->owner) || other->client )  // Don't stop on players.
+		return;
+	self->think = G_FreeEdict;
+	self->nextthink = level.framenum + 1;
 }
 
 void EjectBlooder(edict_t * self, vec3_t start, vec3_t veloc)
@@ -595,7 +598,7 @@ void EjectBlooder(edict_t * self, vec3_t start, vec3_t veloc)
 	spd = 0;
 	VectorScale(forward, spd, blooder->velocity);
 	blooder->solid = SOLID_NOT;
-	blooder->movetype = MOVETYPE_TOSS;
+	blooder->movetype = MOVETYPE_BLOOD;  // Allow dripping blood to make a splat.
 	blooder->s.modelindex = gi.modelindex("sprites/null.sp2");
 	blooder->s.effects |= EF_GIB;
 	blooder->owner = self;

--- a/source/a_game.c
+++ b/source/a_game.c
@@ -874,6 +874,10 @@ edict_t *FindEdictByClassnum(char *classname, int classnum)
 
 /********* Bulletholes/wall stuff ***********/
 
+void DoNothing( edict_t *self )
+{
+}
+
 // Decal/splat attached to some moving entity.
 void DecalOrSplatThink( edict_t *self )
 {
@@ -958,7 +962,7 @@ void AddDecal(edict_t * self, trace_t * tr)
 	decal->owner = self;
 	decal->touch = NULL;
 	decal->nextthink = level.framenum + bholelife->value * HZ;
-	decal->think = bholelife->value ? DecalDie : NULL;
+	decal->think = bholelife->value ? DecalDie : DoNothing;
 	decal->classname = "decal";
 	decal->classnum = decals;
 
@@ -1040,7 +1044,7 @@ void AddSplat(edict_t * self, vec3_t point, trace_t * tr)
 	splat->owner = self;
 	splat->touch = NULL;
 	splat->nextthink = level.framenum + splatlife->value * HZ; // - (splats * .05);
-	splat->think = splatlife->value ? SplatDie : NULL;
+	splat->think = splatlife->value ? SplatDie : DoNothing;
 	splat->classname = "splat";
 	splat->classnum = splats;
 

--- a/source/a_team.c
+++ b/source/a_team.c
@@ -1301,6 +1301,11 @@ void CleanLevel ()
 			case SNIPER_ANUM:
 				G_FreeEdict( ent );
 				break;
+			default:
+				if((strcmp( ent->classname, "decal" ) == 0)
+				|| (strcmp( ent->classname, "splat" ) == 0)
+				|| (strcmp( ent->classname, "shell" ) == 0))
+					G_FreeEdict( ent );
 		}
 	}
 	

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -878,38 +878,16 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 		client->damage_blood += take;
 		client->damage_knockback += knockback;
 		//zucc handle adding bleeding here
-		if (damage_type && bleeding)	// one of the hit location weapons
+		if (bleeding)
 		{
-			/* zucc add in partial bleeding, changed
-			if ( client->bleeding < 4*damage*BLEED_TIME )
-			{
-			client->bleeding = 4*damage*BLEED_TIME + client->bleeding/2;
-
-			}
-			else
-			{
-			client->bleeding += damage*BLEED_TIME*2;
-
-			} */
 			client->bleeding += damage * BLEED_TIME;
 			
-			VectorSubtract (point, targ->absmax, targ->client->bleedloc_offset);
-			//VectorSubtract(point, targ->s.origin,  client->bleedloc_offset);
-			
-			client->bleeddelay = level.framenum + 2 * HZ;  // 2 seconds
-		}
-		else if (bleeding)
-		{
-			/*
-			if ( client->bleeding < damage*BLEED_TIME )
-			{
-			client->bleeding = damage*BLEED_TIME;
-			//client->bleedcount = 0;
-			} */
-			client->bleeding += damage * BLEED_TIME;
-			
-			VectorSubtract (point, targ->absmax, targ->client->bleedloc_offset);
-			//VectorSubtract(point, targ->s.origin,  client->bleedloc_offset);
+			vec3_t fwd, right, up, offset;
+			AngleVectors( targ->s.angles, fwd, right, up );
+			VectorSubtract( point, targ->s.origin, offset );
+			targ->client->bleedloc_offset[0] = DotProduct( offset, fwd );
+			targ->client->bleedloc_offset[1] = DotProduct( offset, right );
+			targ->client->bleedloc_offset[2] = DotProduct( offset, up );
 			
 			client->bleeddelay = level.framenum + 2 * HZ;  // 2 seconds
 		}

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -753,30 +753,22 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 		case MOVETYPE_STOP:
 			break;
 		default:
+			if( mod != MOD_FALLING )
 			{
-				float mass;
-				vec3_t flydir;
+				float mass = max( targ->mass, 50 );
+				vec3_t flydir = {0.f,0.f,0.f}, kvel = {0.f,0.f,0.f};
 
-				if (mod != MOD_FALLING) {
-					VectorNormalize2(dir, flydir);
-					flydir[2] += 0.4f;
-				}
-				else {
-					VectorClear(flydir);
-				}
+				VectorNormalize2( dir, flydir );
+				flydir[2] += 0.4f;
 
-				mass = (targ->mass < 50) ? 50 : targ->mass;
+				float accel_scale = (client && (attacker == targ)) ? 1600.f : 500.f; // the rocket jump hack...
+				VectorScale( flydir, accel_scale * (float) knockback / mass, kvel );
 
-				if (client && attacker == targ)
-					mass = 1600.0f * (float)knockback / mass;	// the rocket jump hack...
-				else
-					mass = 500.0f * (float)knockback / mass;
-
-				VectorMA(targ->velocity, mass, flydir, targ->velocity);
+				VectorAdd( targ->velocity, kvel, targ->velocity );
 
 				// Raptor007: Don't consider knockback part of falling damage (instant kick death).
 				if( client )
-					VectorMA( client->oldvelocity, mass, flydir, client->oldvelocity );
+					VectorAdd( client->oldvelocity, kvel, client->oldvelocity );
 			}
 			break;
 		}

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -333,7 +333,7 @@ void spray_blood(edict_t *self, vec3_t start, vec3_t dir, int damage, int mod)
 	VectorClear(blood->maxs);
 	blood->s.modelindex = gi.modelindex("sprites/null.sp2");
 	blood->owner = self;
-	blood->nextthink = level.framenum + min( speed, 1000 ) * HZ / 1000;	//3.2;
+	blood->nextthink = level.framenum + max( speed, 500 ) * HZ / 1000;  //3.2;
 	blood->touch = blood_spray_touch;
 	blood->think = BloodSprayThink;
 	blood->dmg = damage;

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -278,7 +278,7 @@ void BloodSprayThink(edict_t *self)
 
 void blood_spray_touch(edict_t *ent, edict_t *other, cplane_t *plane, csurface_t *surf)
 {
-	if (other == ent->owner)
+	if( (other == ent->owner) || other->client )  // Don't stop on players.
 		return;
 	ent->think = G_FreeEdict;
 	ent->nextthink = level.framenum + 1;
@@ -333,7 +333,7 @@ void spray_blood(edict_t *self, vec3_t start, vec3_t dir, int damage, int mod)
 	VectorClear(blood->maxs);
 	blood->s.modelindex = gi.modelindex("sprites/null.sp2");
 	blood->owner = self;
-	blood->nextthink = level.framenum + speed * HZ / 1000;	//3.2;
+	blood->nextthink = level.framenum + min( speed, 1000 ) * HZ / 1000;	//3.2;
 	blood->touch = blood_spray_touch;
 	blood->think = BloodSprayThink;
 	blood->dmg = damage;

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -333,7 +333,7 @@ void spray_blood(edict_t *self, vec3_t start, vec3_t dir, int damage, int mod)
 	VectorClear(blood->maxs);
 	blood->s.modelindex = gi.modelindex("sprites/null.sp2");
 	blood->owner = self;
-	blood->nextthink = level.framenum + max( speed, 500 ) * HZ / 1000;  //3.2;
+	blood->nextthink = level.framenum + speed * HZ / 1000;  //3.2;
 	blood->touch = blood_spray_touch;
 	blood->think = BloodSprayThink;
 	blood->dmg = damage;

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -892,9 +892,11 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 
 			} */
 			client->bleeding += damage * BLEED_TIME;
+			
 			VectorSubtract (point, targ->absmax, targ->client->bleedloc_offset);
 			//VectorSubtract(point, targ->s.origin,  client->bleedloc_offset);
-
+			
+			client->bleeddelay = level.framenum + 2 * HZ;  // 2 seconds
 		}
 		else if (bleeding)
 		{
@@ -905,9 +907,11 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 			//client->bleedcount = 0;
 			} */
 			client->bleeding += damage * BLEED_TIME;
+			
 			VectorSubtract (point, targ->absmax, targ->client->bleedloc_offset);
 			//VectorSubtract(point, targ->s.origin,  client->bleedloc_offset);
-
+			
+			client->bleeddelay = level.framenum + 2 * HZ;  // 2 seconds
 		}
 		if (attacker->client)
 		{

--- a/source/g_trigger.c
+++ b/source/g_trigger.c
@@ -479,7 +479,7 @@ void hurt_touch (edict_t * self, edict_t * other, cplane_t * plane, csurface_t *
 
 	if (!(self->spawnflags & 4))
 	{
-		if ((level.framenum % 10) == 0)
+		if ((level.framenum % HZ) == 0)
 			gi.sound(other, CHAN_AUTO, self->noise_index, 1, ATTN_NORM, 0);
 	}
 

--- a/source/g_utils.c
+++ b/source/g_utils.c
@@ -179,7 +179,7 @@ void G_UseTargets (edict_t * ent, edict_t * activator)
 		// create a temp object to fire at a later time
 		t = G_Spawn ();
 		t->classname = "DelayedUse";
-		t->nextthink = level.framenum + ent->delay * HZ;
+		t->nextthink = level.framenum + ceil( ent->delay * HZ );
 		t->think = Think_Delay;
 		t->activator = activator;
 		if (!activator)

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -648,7 +648,7 @@ void ClientObituary(edict_t * self, edict_t * inflictor, edict_t * attacker)
 	char *message2;
 	char death_msg[1024];	// enough in all situations? -FB
 	qboolean friendlyFire;
-	int special = 0;
+	char *special_message = NULL;
 	int n;
 
 	self->client->resp.ctf_capstreak = 0;
@@ -695,15 +695,16 @@ void ClientObituary(edict_t * self, edict_t * inflictor, edict_t * attacker)
 	if (!message) {
 		switch (mod) {
 		case MOD_BREAKINGGLASS:
+			if( self->client->push_timeout > 25 )
+				special_message = "was thrown through a window by";
 			message = "ate too much glass";
 			break;
 		case MOD_SUICIDE:
 			message = "is done with the world";
 			break;
 		case MOD_FALLING:
-			// moved falling to the end
-			if (self->client->push_timeout)
-				special = 1;
+			if( self->client->push_timeout )
+				special_message = "was taught how to fly by";
 			//message = "hit the ground hard, real hard";
 			if (self->client->pers.gender == GENDER_MALE)
 				message = "plummets to his death";
@@ -719,9 +720,13 @@ void ClientObituary(edict_t * self, edict_t * inflictor, edict_t * attacker)
 			message = "sank like a rock";
 			break;
 		case MOD_SLIME:
+			if( self->client->push_timeout )
+				special_message = "melted thanks to";
 			message = "melted";
 			break;
 		case MOD_LAVA:
+			if( self->client->push_timeout )
+				special_message = "was drop-kicked into the lava by";
 			message = "does a back flip into the lava";
 			break;
 		case MOD_EXPLOSIVE:
@@ -740,6 +745,8 @@ void ClientObituary(edict_t * self, edict_t * inflictor, edict_t * attacker)
 		case MOD_BOMB:
 		case MOD_SPLASH:
 		case MOD_TRIGGER_HURT:
+			if( self->client->push_timeout )
+				special_message = "was shoved off the edge by";
 			message = "was in the wrong place";
 			break;
 		}
@@ -748,11 +755,11 @@ void ClientObituary(edict_t * self, edict_t * inflictor, edict_t * attacker)
 	if (message)
 	{
 		// handle falling with an attacker set
-		if (special && self->client->attacker && self->client->attacker->client
+		if (special_message && self->client->attacker && self->client->attacker->client
 		&& (self->client->attacker->client != self->client))
 		{
-			sprintf(death_msg, "%s was taught how to fly by %s\n",
-				self->client->pers.netname, self->client->attacker->client->pers.netname);
+			sprintf(death_msg, "%s %s %s\n",
+				self->client->pers.netname, special_message, self->client->attacker->client->pers.netname);
 			PrintDeathMessage(death_msg, self);
 			IRC_printf(IRC_T_KILL, death_msg);
 			AddKilledPlayer(self->client->attacker, self);

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -695,7 +695,7 @@ void ClientObituary(edict_t * self, edict_t * inflictor, edict_t * attacker)
 	if (!message) {
 		switch (mod) {
 		case MOD_BREAKINGGLASS:
-			if( self->client->push_timeout > 25 )
+			if( self->client->push_timeout > 40 )
 				special_message = "was thrown through a window by";
 			message = "ate too much glass";
 			break;

--- a/source/p_view.c
+++ b/source/p_view.c
@@ -1110,14 +1110,16 @@ void Do_Bleeding (edict_t * ent)
 		}
 		if (ent->client->bleeddelay <= level.framenum)
 		{
-			vec3_t pos;
-			ent->client->bleeddelay = level.framenum + 2 * HZ;	// 2 seconds
-			VectorAdd (ent->client->bleedloc_offset, ent->absmax, pos);
+			ent->client->bleeddelay = level.framenum + 2 * HZ;  // 2 seconds
+			
+			vec3_t fwd, right, up, pos;
+			AngleVectors( ent->s.angles, fwd, right, up );
+			pos[0] = ent->s.origin[0] + fwd[0] * ent->client->bleedloc_offset[0] + right[0] * ent->client->bleedloc_offset[1] + up[0] * ent->client->bleedloc_offset[2];
+			pos[1] = ent->s.origin[1] + fwd[1] * ent->client->bleedloc_offset[0] + right[1] * ent->client->bleedloc_offset[1] + up[1] * ent->client->bleedloc_offset[2];
+			pos[2] = ent->s.origin[2] + fwd[2] * ent->client->bleedloc_offset[0] + right[2] * ent->client->bleedloc_offset[1] + up[2] * ent->client->bleedloc_offset[2];
+			
 			//gi.cprintf(ent, PRINT_HIGH, "Bleeding now.\n");
 			EjectBlooder (ent, pos, pos);
-
-			// do bleeding
-
 		}
 	}
 

--- a/source/p_view.c
+++ b/source/p_view.c
@@ -1112,14 +1112,17 @@ void Do_Bleeding (edict_t * ent)
 		{
 			ent->client->bleeddelay = level.framenum + 2 * HZ;  // 2 seconds
 			
-			vec3_t fwd, right, up, pos;
+			vec3_t fwd, right, up, pos, vel;
 			AngleVectors( ent->s.angles, fwd, right, up );
-			pos[0] = ent->s.origin[0] + fwd[0] * ent->client->bleedloc_offset[0] + right[0] * ent->client->bleedloc_offset[1] + up[0] * ent->client->bleedloc_offset[2];
-			pos[1] = ent->s.origin[1] + fwd[1] * ent->client->bleedloc_offset[0] + right[1] * ent->client->bleedloc_offset[1] + up[1] * ent->client->bleedloc_offset[2];
-			pos[2] = ent->s.origin[2] + fwd[2] * ent->client->bleedloc_offset[0] + right[2] * ent->client->bleedloc_offset[1] + up[2] * ent->client->bleedloc_offset[2];
+			vel[0] = fwd[0] * ent->client->bleedloc_offset[0] + right[0] * ent->client->bleedloc_offset[1] + up[0] * ent->client->bleedloc_offset[2];
+			vel[1] = fwd[1] * ent->client->bleedloc_offset[0] + right[1] * ent->client->bleedloc_offset[1] + up[1] * ent->client->bleedloc_offset[2];
+			vel[2] = fwd[2] * ent->client->bleedloc_offset[0] + right[2] * ent->client->bleedloc_offset[1] + up[2] * ent->client->bleedloc_offset[2];
+			VectorAdd( ent->s.origin, vel, pos );
+			if( vel[2] < 0. )
+				vel[2] = 0;
 			
 			//gi.cprintf(ent, PRINT_HIGH, "Bleeding now.\n");
-			EjectBlooder (ent, pos, pos);
+			EjectBlooder( ent, pos, vel );
 		}
 	}
 


### PR DESCRIPTION
Fixed T_Damage knockback bug that threw you away from the cactus on map "tequila".
Fixed G_UseTargets delay bug that prevented death in the pit on map "rooftops".
Credit kills for knocking into hurt brushes such as pits and lava.
Clear splats/bholes each round.
Bleeding leaves splats if splats are enabled.