### PR TITLE
Non-exploitable leg damage stumble, and better sv_fps lasersight/flashlight.

### DIFF
--- a/source/a_cmds.c
+++ b/source/a_cmds.c
@@ -205,7 +205,8 @@ void LaserSightThink(edict_t * self)
 	int height = 0;
 
 	// zucc compensate for weapon ride up
-	VectorAdd(self->owner->client->v_angle, self->owner->client->kick_angles, angles);
+	float *kick_angles = (FRAMEDIV == 1) ? self->owner->client->kick_angles : self->owner->client->ps.kick_angles;
+	VectorAdd(self->owner->client->v_angle, kick_angles, angles);
 	AngleVectors(angles, forward, right, up);
 
 	if (self->owner->client->lasersight != self) {

--- a/source/a_team.c
+++ b/source/a_team.c
@@ -2084,27 +2084,23 @@ int CheckTeamRules (void)
 				}
 				else
 				{
-					if (warmup->value) {
-						char buf[64];
-						int warmup_length = max(warmup->value, 20);
-						sprintf (buf, "The round will begin in %d seconds!", warmup_length);
-						CenterPrintAll (buf);
-						team_round_countdown = warmup_length * 10 + 1;
-					} else {
-						CenterPrintAll ("The round will begin in 20 seconds!");
-						team_round_countdown = 201;
-						// JBravo: Autostart q2pro MVD2 recording on the server
-						if( use_mvd2->value )
-						{
-							tnow = time(NULL);
-							now = localtime(&tnow);
-							strftime( ltm, 64, "%Y%m%d-%H%M%S", now );
-							Com_sprintf( mvdstring, sizeof(mvdstring), "mvdrecord %s-%s\n", ltm, level.mapname );
-							gi.AddCommandString( mvdstring );
-							gi.bprintf( PRINT_HIGH, "Starting MVD recording to file %s-%s.mvd2\n", ltm, level.mapname );
-						}
-						// JBravo: End MVD2
+					int warmup_length = max( warmup->value, round_begin->value );
+					char buf[64] = "";
+					sprintf( buf, "The round will begin in %d seconds!", warmup_length );
+					CenterPrintAll( buf );
+					team_round_countdown = warmup_length * 10 + 2;
+
+					// JBravo: Autostart q2pro MVD2 recording on the server
+					if( use_mvd2->value )
+					{
+						tnow = time(NULL);
+						now = localtime(&tnow);
+						strftime( ltm, 64, "%Y%m%d-%H%M%S", now );
+						Com_sprintf( mvdstring, sizeof(mvdstring), "mvdrecord %s-%s\n", ltm, level.mapname );
+						gi.AddCommandString( mvdstring );
+						gi.bprintf( PRINT_HIGH, "Starting MVD recording to file %s-%s.mvd2\n", ltm, level.mapname );
 					}
+					// JBravo: End MVD2
 				}
 			}
 		}

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1018,7 +1018,9 @@ extern cvar_t *hc_single;
 extern cvar_t *wp_flags;
 extern cvar_t *itm_flags;
 extern cvar_t *use_classic;	// Use_classic resets weapon balance to 1.52
+
 extern cvar_t *warmup;
+extern cvar_t *round_begin;
 extern cvar_t *spectator_hud;
 
 extern cvar_t *fraglimit;

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -445,7 +445,9 @@ cvar_t *radio_repeat;		// same as radio_max, only for repeats
 cvar_t *radio_repeat_time;
 
 cvar_t *use_classic;		// Used to reset spread/gren strength to 1.52
+
 cvar_t *warmup;
+cvar_t *round_begin;
 cvar_t *spectator_hud;
 
 void SpawnEntities (char *mapname, char *entities, char *spawnpoint);

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -530,6 +530,7 @@ void InitGame( void )
 	flood_threshold = gi.cvar( "flood_threshold", "4", 0 );
 
 	warmup = gi.cvar( "warmup", "0", CVAR_LATCH );
+	round_begin = gi.cvar( "round_begin", "20", 0 );
 	spectator_hud = gi.cvar( "spectator_hud", "0", CVAR_LATCH );
 
 	use_mvd2 = gi.cvar( "use_mvd2", "0", 0 );	// JBravo: q2pro MVD2 recording. 0 = off, 1 = on

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2869,10 +2869,13 @@ void ClientThink(edict_t * ent, usercmd_t * ucmd)
 		if( client->leg_damage && client->leghits && ent->groundentity
 		&& ((level.framenum / game.framediv) % 6 <= 2) )
 		{
-			pm.cmd.forwardmove /= 4 * client->leghits;
-			pm.cmd.sidemove    /= 4 * client->leghits;
-			if( pm.cmd.upmove > 0 )
-				pm.cmd.upmove  /= 4 * client->leghits;
+			int slowdown = 4 * client->leghits;
+			if( pm.cmd.upmove >= 0 )
+				pm.cmd.upmove /= slowdown;
+			else
+				slowdown *= 2; // Reduce crouch walk input even more.
+			pm.cmd.forwardmove /= slowdown;
+			pm.cmd.sidemove    /= slowdown;
 		}
 
 		pm.trace = PM_trace;	// adds default parms

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2865,6 +2865,15 @@ void ClientThink(edict_t * ent, usercmd_t * ucmd)
 
 		pm.cmd = *ucmd;
 
+		// Stumbling movement with leg damage.
+		if( client->leg_damage && client->leghits && ent->groundentity
+		&& ((level.framenum / game.framediv) % 6 <= 2) )
+		{
+			pm.cmd.forwardmove /= 4 * client->leghits;
+			pm.cmd.sidemove    /= 4 * client->leghits;
+			pm.cmd.upmove      /= 4 * client->leghits;
+		}
+
 		pm.trace = PM_trace;	// adds default parms
 		pm.pointcontents = gi.pointcontents;
 		// perform a pmove
@@ -2894,31 +2903,9 @@ void ClientThink(edict_t * ent, usercmd_t * ucmd)
 			if (ent->groundentity && pm.s.velocity[2] > 10) {
 				ent->velocity[2] = 0.0;
 			}
-
-			// zucc stumbling associated with leg damage
-			if ((level.framenum / game.framediv) % 6 <= 2) {
-				//Slow down code FOO/zucc
-				if (ent->groundentity && pm.groundentity) {
-					ent->velocity[0] /= 4 * ent->client->leghits;	//FOO  
-					ent->velocity[1] /= 4 * ent->client->leghits;	//FOO  
-					if (ent->velocity[2] > 0)
-						ent->velocity[2] /= 4 * ent->client->leghits;	//FOO     
-				}
-				if ((level.framenum / game.framediv) % (6 * 12) == 0 && client->leg_damage > 1)
-					gi.sound(ent, CHAN_BODY, gi.soundindex(va("*pain100_1.wav")), 1, ATTN_NORM, 0);
-
-				ent->velocity[0] = (float)((int)(ent->velocity[0] * 8)) / 8;
-				ent->velocity[1] = (float)((int)(ent->velocity[1] * 8)) / 8;
-				ent->velocity[2] = (float)((int)(ent->velocity[2] * 8)) / 8;
-			}
-
 		} else {
 			// don't play sounds if they have leg damage, they can't jump anyway
 			if (ent->groundentity && !pm.groundentity && pm.cmd.upmove >= 10 && pm.waterlevel == 0) {
-				/* don't play jumps period.
-				gi.sound(ent, CHAN_VOICE, gi.soundindex("*jump1.wav"), 1, ATTN_NORM, 0);
-				PlayerNoise(ent, ent->s.origin, PNOISE_SELF);
-				*/
 				ent->client->jumping = 1;
 			}
 		}

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2871,7 +2871,8 @@ void ClientThink(edict_t * ent, usercmd_t * ucmd)
 		{
 			pm.cmd.forwardmove /= 4 * client->leghits;
 			pm.cmd.sidemove    /= 4 * client->leghits;
-			pm.cmd.upmove      /= 4 * client->leghits;
+			if( pm.cmd.upmove > 0 )
+				pm.cmd.upmove  /= 4 * client->leghits;
 		}
 
 		pm.trace = PM_trace;	// adds default parms

--- a/source/tng_flashlight.c
+++ b/source/tng_flashlight.c
@@ -52,7 +52,7 @@ void FL_make (edict_t * self)
 	flashlight->s.skinnum = 0;
 	flashlight->s.effects |= EF_HYPERBLASTER; // Other effects can be used here, such as flag1, but these look corney and dull. Try stuff and tell me if you find anything cool (EF_HYPERBLASTER)
 	flashlight->think = FL_think;
-	flashlight->nextthink = level.framenum + FRAMEDIV;
+	flashlight->nextthink = level.framenum + 1;
 
 	self->client->flashlight = flashlight;
 }
@@ -108,7 +108,7 @@ void FL_think (edict_t * self)
 	VectorCopy(tr.endpos,self->s.origin);
 
 	gi.linkentity (self);
-	self->nextthink = level.framenum + FRAMEDIV; */
+	self->nextthink = level.framenum + 1; */
 
 	if (self->owner->client->pers.firing_style == ACTION_FIRING_CLASSIC)
 		height = 8;
@@ -134,6 +134,6 @@ void FL_think (edict_t * self)
 	VectorCopy (tr.endpos, self->s.origin);
 
 	gi.linkentity (self);
-	self->nextthink = level.framenum + FRAMEDIV;
+	self->nextthink = level.framenum + 1;
 
 }

--- a/source/tng_flashlight.c
+++ b/source/tng_flashlight.c
@@ -76,11 +76,10 @@ void FL_think (edict_t * self)
      vec3_t forward,right,up;
      trace_t tr; */
 
-  //AngleVectors (self->owner->client->v_angle, forward, right, up);
-  VectorAdd (self->owner->client->v_angle, self->owner->client->kick_angles,
-	     angles);
-  AngleVectors ( /*self->owner->client->v_angle */ angles, forward, right,
-		up);
+	//AngleVectors (self->owner->client->v_angle, forward, right, up);
+	float *kick_angles = (FRAMEDIV == 1) ? self->owner->client->kick_angles : self->owner->client->ps.kick_angles;
+	VectorAdd( self->owner->client->v_angle, kick_angles, angles );
+	AngleVectors( /*self->owner->client->v_angle */ angles, forward, right, up );
 
 /*	VectorSet(offset,24 , 6, self->owner->viewheight-7);
 	G_ProjectSource (self->owner->s.origin, offset, forward, right, start);


### PR DESCRIPTION
The most important fix is the new stumble code, which prevents using cl_maxfps to cheat.

New `round_begin` cvar lets you adjust the round begin delay, including the countdown.  The default is still 20 seconds, but I much prefer 15 for my server (5 second wait + 10 second countdown).

The other changes improve the appearance of lasersight and flashlight when sv_fps > 10.