### PR TITLE
More responsive sv_fps gameplay, and fixed many bugs!

### DIFF
--- a/source/a_cmds.c
+++ b/source/a_cmds.c
@@ -1017,10 +1017,7 @@ void Cmd_Time(edict_t * ent)
 		return;
 	}
 
-	if (matchmode->value)
-		gametime = level.matchTime;
-	else
-		gametime = level.time;
+	gametime = level.matchTime;
 
 	mins = gametime / 60;
 	secs = gametime % 60;

--- a/source/a_ctf.c
+++ b/source/a_ctf.c
@@ -1100,8 +1100,7 @@ qboolean CTFCheckRules(void)
 
 	if( timelimit->value > 0 && ctfgame.type > 0 )
 	{
-		float gametime = matchmode->value ? level.matchTime : level.time;
-		if( ctfgame.halftime == 0 && gametime >= (timelimit->value * 60) / 2 - 60 )
+		if( ctfgame.halftime == 0 && level.matchTime >= (timelimit->value * 60) / 2 - 60 )
 		{
 			if( use_warnings->value )
 			{
@@ -1110,13 +1109,13 @@ qboolean CTFCheckRules(void)
 			}
 			ctfgame.halftime = 1;
 		}
-		else if( ctfgame.halftime == 1 && gametime >= (timelimit->value * 60) / 2 - 10 )
+		else if( ctfgame.halftime == 1 && level.matchTime >= (timelimit->value * 60) / 2 - 10 )
 		{
 			if( use_warnings->value )
 				gi.sound( &g_edicts[0], CHAN_VOICE | CHAN_NO_PHS_ADD, gi.soundindex("world/10_0.wav"), 1.0, ATTN_NONE, 0.0 );
 			ctfgame.halftime = 2;
 		}
-		else if( ctfgame.halftime < 3 && gametime >= (timelimit->value * 60) / 2 + 1 )
+		else if( ctfgame.halftime < 3 && level.matchTime >= (timelimit->value * 60) / 2 + 1 )
 		{
 			team_round_going = team_round_countdown = team_game_going = 0;
 			MakeAllLivePlayersObservers ();

--- a/source/a_ctf.h
+++ b/source/a_ctf.h
@@ -39,7 +39,7 @@ typedef struct ctfgame_s {
 	int total1, total2;	// these are only set when going into intermission!
 	int last_flag_capture;
 	int last_capture_team;
-	qboolean halftime;
+	int halftime;
 
 	/* CTF configuration from .ctf */
 	int type;		// 0 = normal, 1 = off/def

--- a/source/a_team.c
+++ b/source/a_team.c
@@ -1340,6 +1340,15 @@ void ResetScores (qboolean playerScores)
 		gi.cvar_forceset(teams[i].teamscore->name, "0");
 	}
 
+	ctfgame.team1 = 0;
+	ctfgame.team2 = 0;
+	ctfgame.total1 = 0;
+	ctfgame.total2 = 0;
+	ctfgame.last_flag_capture = 0;
+	ctfgame.last_capture_team = 0;
+	if( matchmode->value )
+		ctfgame.halftime = 0;
+
 	if(!playerScores)
 		return;
 

--- a/source/a_team.c
+++ b/source/a_team.c
@@ -2820,7 +2820,13 @@ void A_ScoreboardMessage (edict_t * ent, edict_t * killer)
 			cl_ent = g_edicts + 1 + (cl - game.clients);
 
 			snprintf( team_buf,   6, " %c%c%c ", (cl->resp.team ? (cl->resp.team + '0') : ' '), (IS_CAPTAIN(cl_ent) ? 'C' : ' '), (cl->resp.subteam ? 'S' : ' ') );
-			snprintf( time_buf,   6, " %4i", min( 9999, (level.framenum - cl->resp.enterframe) / (60 * HZ) ) );
+			int minutes = (level.framenum - cl->resp.enterframe) / (60 * HZ);
+			if( minutes < 60 )
+				snprintf( time_buf, 6, " %4i", minutes );
+			else if( minutes < 600 )
+				snprintf( time_buf, 6, " %1i:%02i", minutes / 60, minutes % 60 );
+			else
+				snprintf( time_buf, 6, " %3ih", min( 999, minutes / 60 ) );
 			snprintf( ping_buf,   6, " %4i", min( 9999, cl->ping ) );
 			snprintf( caps_buf,   6, " %4i", min( 9999, cl->resp.ctf_caps ) );
 			snprintf( score_buf,  7, " %5i", min( 99999, cl->resp.score) );

--- a/source/a_team.c
+++ b/source/a_team.c
@@ -1346,8 +1346,7 @@ void ResetScores (qboolean playerScores)
 	ctfgame.total2 = 0;
 	ctfgame.last_flag_capture = 0;
 	ctfgame.last_capture_team = 0;
-	if( matchmode->value )
-		ctfgame.halftime = 0;
+	ctfgame.halftime = 0;
 
 	if(!playerScores)
 		return;
@@ -1593,7 +1592,7 @@ void RunWarmup ()
 	int i, dead;
 	edict_t *ent;
 
-	if (!warmup->value || level.matchTime > 0 || team_round_going || lights_camera_action || (team_round_countdown > 0 && team_round_countdown <= 101))
+	if (!warmup->value || (matchmode->value && level.matchTime > 0) || team_round_going || lights_camera_action || (team_round_countdown > 0 && team_round_countdown <= 101))
 		return;
 
 	if (!in_warmup)
@@ -1744,9 +1743,7 @@ qboolean CheckTimelimit( void )
 {
 	if (timelimit->value > 0)
 	{
-		float gametime = matchmode->value ? level.matchTime : level.time;
-
-		if (gametime >= timelimit->value * 60)
+		if (level.matchTime >= timelimit->value * 60)
 		{
 			int i;
 
@@ -1778,18 +1775,18 @@ qboolean CheckTimelimit( void )
 		// Otherwise, use_warnings should warn about 3 minutes and 1 minute left, but only if there aren't round ending warnings.
 		if( use_warnings->value && (ctf->value || ! roundtimelimit->value) )
 		{
-			if( timewarning < 3 && ctf->value && gametime >= timelimit->value * 60 - 10 )
+			if( timewarning < 3 && ctf->value && level.matchTime >= timelimit->value * 60 - 10 )
 			{
 				gi.sound( &g_edicts[0], CHAN_VOICE | CHAN_NO_PHS_ADD, gi.soundindex("world/10_0.wav"), 1.0, ATTN_NONE, 0.0 );
 				timewarning = 3;
 			}
-			else if( timewarning < 2 && gametime >= (timelimit->value - 1) * 60 )
+			else if( timewarning < 2 && level.matchTime >= (timelimit->value - 1) * 60 )
 			{
 				CenterPrintAll( "1 MINUTE LEFT..." );
 				gi.sound( &g_edicts[0], CHAN_VOICE | CHAN_NO_PHS_ADD, gi.soundindex("tng/1_minute.wav"), 1.0, ATTN_NONE, 0.0 );
 				timewarning = 2;
 			}
-			else if( timewarning < 1 && (! ctf->value) && timelimit->value > 3 && gametime >= (timelimit->value - 3) * 60 )
+			else if( timewarning < 1 && (! ctf->value) && timelimit->value > 3 && level.matchTime >= (timelimit->value - 3) * 60 )
 			{
 				CenterPrintAll( "3 MINUTES LEFT..." );
 				gi.sound( &g_edicts[0], CHAN_VOICE | CHAN_NO_PHS_ADD, gi.soundindex("tng/3_minutes.wav"), 1.0, ATTN_NONE, 0.0 );
@@ -1951,7 +1948,7 @@ int WonGame (int winner)
 	}
 	vNewRound ();
 
-	if (teamplay->value && (!timelimit->value || level.time <= ((timelimit->value * 60) - 5)))
+	if (teamplay->value && (!timelimit->value || level.matchTime <= ((timelimit->value * 60) - 5)))
 	{
 		arg[0] = '\0';
 		for (i = 0; i < game.maxclients; i++)

--- a/source/cgf_sfx_glass.c
+++ b/source/cgf_sfx_glass.c
@@ -599,6 +599,7 @@ CGF_SFX_HideBreakableGlass (edict_t * aGlassPane)
       if (decal->owner == aGlassPane)
 	{
 	  // make it goaway in the next frame
+	  decal->think = G_FreeEdict;
 	  decal->nextthink = level.framenum + 1;
 	}
     }
@@ -608,6 +609,7 @@ CGF_SFX_HideBreakableGlass (edict_t * aGlassPane)
       if (decal->owner == aGlassPane)
 	{
 	  // make it goaway in the next frame
+	  decal->think = G_FreeEdict;
 	  decal->nextthink = level.framenum + 1;
 	}
     }

--- a/source/g_func.c
+++ b/source/g_func.c
@@ -172,9 +172,14 @@ static void Move_Begin(edict_t *ent)
 	traveltime = HZ / frames;
 	VectorScale(destdelta, traveltime, ent->velocity);
 
+#ifndef NO_FPS
+	// Recalculate frequently to avoid compound position error from velocity rounding.
+	NEXT_FRAME( ent, Move_Begin );
+#else
 	// set nextthink to trigger a think when dest is reached
 	ent->nextthink = level.framenum + (int)frames;
 	ent->think = Move_Final;
+#endif
 }
 
 static void AccelMove_Think( edict_t *ent );
@@ -257,9 +262,14 @@ static void AngleMove_Begin(edict_t *ent)
 	traveltime = HZ / frames;
 	VectorScale(destdelta, traveltime, ent->avelocity);
 
+#ifndef NO_FPS
+	// Recalculate frequently to avoid compound position error from velocity rounding.
+	NEXT_FRAME( ent, AngleMove_Begin );
+#else
 	// set nextthink to trigger a think when dest is reached
 	ent->nextthink = level.framenum + (int)frames;
 	ent->think = AngleMove_Final;
+#endif
 }
 
 static void AngleMove_Calc(edict_t *ent, void (*func) (edict_t *))

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1522,7 +1522,7 @@ struct gclient_s
 	int			oldbuttons;
 	int			latched_buttons;
 
-	qboolean	weapon_thunk;
+	int			weapon_last_activity;
 
 	gitem_t		*newweapon;
 

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1560,6 +1560,7 @@ struct gclient_s
 	int			anim_priority;
 	qboolean	anim_duck;
 	qboolean	anim_run;
+	int			anim_framesync;
 
 	// powerup timers
 	int			quad_framenum;

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -1061,11 +1061,12 @@ void G_RunFrame (void)
 		level.framenum++;
 		level.time = level.framenum * FRAMETIME;
 
+		// Raptor007: So we can always use level.matchTime for timelimit / halftime.
+		if( ! matchmode->value )
+			level.matchTime += FRAMETIME;
+
 		if (level.framenum % (5 * HZ) == 0) {
-			unsigned int gametime;
-
-			gametime = (matchmode->value) ? level.matchTime : level.time;
-
+			unsigned int gametime = level.matchTime;
 			gi.cvar_forceset(maptime->name, va("%d:%02d", gametime / 60, gametime % 60));
 		}
 	}

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -514,8 +514,8 @@ void InitGame( void )
 	splatlife = gi.cvar( "splatlife", "25", 0 );
 	darkmatch = gi.cvar( "darkmatch", "0", CVAR_LATCH ); // Darkmatch
 	day_cycle = gi.cvar( "day_cycle", "10", 0 ); // Darkmatch cycle time.
-	use_flashlight = gi.cvar( "use_flashlight", "0", CVAR_SERVERINFO );
-	use_classic = gi.cvar( "use_classic", "0", CVAR_SERVERINFO ); // Reset Grenade Strength to 1.52
+	use_flashlight = gi.cvar( "use_flashlight", "0", 0 );
+	use_classic = gi.cvar( "use_classic", "0", 0 ); // Reset Grenade Strength to 1.52
 
 	CGF_SFX_InstallGlassSupport();	// william for CGF (glass fx)
 
@@ -584,7 +584,7 @@ void InitGame( void )
 	{
 		gi.dprintf ("...server supports GMF_VARIABLE_FPS\n");
 		
-		cv = gi.cvar("sv_fps", NULL, 0);
+		cv = gi.cvar( "sv_fps", NULL, CVAR_SERVERINFO );
 		if( cv )
 		{
 			int framediv = (int) cv->value / BASE_FRAMERATE;

--- a/source/g_svcmds.c
+++ b/source/g_svcmds.c
@@ -480,7 +480,7 @@ void SVCmd_Map_restart_f (void)
 void SVCmd_ResetScores_f (void)
 {
 	ResetScores(true);
-	gi.bprintf(PRINT_HIGH, "Scores and time were reset by console.\n");
+	gi.bprintf(PRINT_HIGH, "Scores%s were reset by console.\n", matchmode->value ? " and time" : "");
 }
 
 void SVCmd_SetTeamScore_f( int team )

--- a/source/g_svcmds.c
+++ b/source/g_svcmds.c
@@ -480,7 +480,7 @@ void SVCmd_Map_restart_f (void)
 void SVCmd_ResetScores_f (void)
 {
 	ResetScores(true);
-	gi.bprintf(PRINT_HIGH, "Scores%s were reset by console.\n", matchmode->value ? " and time" : "");
+	gi.bprintf(PRINT_HIGH, "Scores and time were reset by console.\n");
 }
 
 void SVCmd_SetTeamScore_f( int team )

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2261,7 +2261,7 @@ void PutClientInServer(edict_t * ent)
 	client->knife_max = 10;
 	client->grenade_max = 2;
 	client->desired_fov = 90;
-	client->weapon_last_activity = max( 0, level.framenum - 2 * game.framediv );
+
 
 	// clear entity values
 	ent->groundentity = NULL;
@@ -2794,8 +2794,10 @@ trace_t q_gameabi PM_trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end)
 // Raptor007: Allow weapon actions to start happening on any frame.
 static void ClientThinkWeaponIfReady( edict_t *ent, qboolean update_idle )
 {
+	if( ! ent->client->weapon_last_activity )
+		ent->client->weapon_last_activity = level.framenum;
 	// If it's too soon since the last non-idle think, keep waiting.
-	if( level.framenum < ent->client->weapon_last_activity + game.framediv )
+	else if( level.framenum < ent->client->weapon_last_activity + game.framediv )
 		return;
 
 	// Clear weapon kicks.

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2967,6 +2967,9 @@ void ClientThink(edict_t * ent, usercmd_t * ucmd)
 		// stop manipulating doors
 		client->doortoggle = 0;
 
+		if( client->jumping && (ent->solid != SOLID_NOT) && ! lights_camera_action && ! client->uvTime )
+			kick_attack( ent );
+
 		// touch other objects
 		for (i = 0; i < pm.numtouch; i++) {
 			other = pm.touchents[i];
@@ -3151,12 +3154,8 @@ void ClientBeginServerFrame(edict_t * ent)
 
 	if (ent->solid != SOLID_NOT)
 	{
-		if (!lights_camera_action && !client->uvTime) {
-			if (client->jumping)
-				kick_attack( ent );
-			else if (client->punch_desired)
-				punch_attack( ent );
-		}
+		if( client->punch_desired && ! client->jumping && ! lights_camera_action && ! client->uvTime )
+			punch_attack( ent );
 		client->punch_desired = false;
 
 		int idleframes = ppl_idletime->value * HZ;

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -3052,7 +3052,11 @@ void ClientBeginServerFrame(edict_t * ent)
 	if (level.intermission_framenum)
 		return;
 
-	if ((int)motd_time->value > client->resp.motd_refreshes * 2 && ent->client->layout != LAYOUT_MENU) {
+	if( team_round_going && IS_ALIVE(ent) )
+		client->resp.motd_refreshes = motd_time->value;  // Stop showing motd if we're playing.
+	else if( lights_camera_action )
+		client->resp.last_motd_refresh = level.realFramenum;  // Don't interrupt LCA with motd.
+	else if ((int)motd_time->value > client->resp.motd_refreshes * 2 && ent->client->layout != LAYOUT_MENU) {
 		if (client->resp.last_motd_refresh + 2 * HZ < level.realFramenum) {
 			client->resp.last_motd_refresh = level.realFramenum;
 			client->resp.motd_refreshes++;

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2792,7 +2792,7 @@ trace_t q_gameabi PM_trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end)
 }
 
 // Raptor007: Allow weapon actions to start happening on any frame.
-static void ClientThinkWeaponIfReady( edict_t *ent )
+static void ClientThinkWeaponIfReady( edict_t *ent, qboolean update_idle )
 {
 	// If it's too soon since the last non-idle think, keep waiting.
 	if( level.framenum < ent->client->weapon_last_activity + game.framediv )
@@ -2812,7 +2812,7 @@ static void ClientThinkWeaponIfReady( edict_t *ent )
 		ent->client->weapon_last_activity = level.framenum;
 
 	// Only allow the idle animation to update if it's been enough time.
-	else if( level.framenum % game.framediv != ent->client->weapon_last_activity % game.framediv )
+	else if( ! update_idle || level.framenum % game.framediv != ent->client->weapon_last_activity % game.framediv )
 		ent->client->ps.gunframe = old_gunframe;
 }
 
@@ -2999,7 +2999,7 @@ void ClientThink(edict_t * ent, usercmd_t * ucmd)
 			client->latched_buttons = 0;
 			NextChaseMode( ent );
 		} else {
-			ClientThinkWeaponIfReady( ent );
+			ClientThinkWeaponIfReady( ent, false );
 		}
 	}
 
@@ -3094,7 +3094,7 @@ void ClientBeginServerFrame(edict_t * ent)
 	}
 
 	// run weapon animations if it hasn't been done by a ucmd_t
-	ClientThinkWeaponIfReady( ent );
+	ClientThinkWeaponIfReady( ent, true );
 
 	if (ent->deadflag) {
 		// wait for any button just going down

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2794,8 +2794,10 @@ trace_t q_gameabi PM_trace(vec3_t start, vec3_t mins, vec3_t maxs, vec3_t end)
 // Raptor007: Allow weapon actions to start happening on any frame.
 static void ClientThinkWeaponIfReady( edict_t *ent, qboolean update_idle )
 {
+	// If they just spawned, sync up the weapon animation with that.
 	if( ! ent->client->weapon_last_activity )
 		ent->client->weapon_last_activity = level.framenum;
+
 	// If it's too soon since the last non-idle think, keep waiting.
 	else if( level.framenum < ent->client->weapon_last_activity + game.framediv )
 		return;

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2261,7 +2261,7 @@ void PutClientInServer(edict_t * ent)
 	client->knife_max = 10;
 	client->grenade_max = 2;
 	client->desired_fov = 90;
-
+	client->weapon_last_activity = max( 0, level.framenum - 2 * game.framediv );
 
 	// clear entity values
 	ent->groundentity = NULL;
@@ -3024,11 +3024,11 @@ void ClientThink(edict_t * ent, usercmd_t * ucmd)
 		}
 	}
 
-	if (ucmd->forwardmove || ucmd->sidemove || client->oldbuttons != client->buttons) {
+	if( ucmd->forwardmove || ucmd->sidemove || client->oldbuttons != client->buttons
+		|| (ent->solid == SOLID_NOT && ent->deadflag != DEAD_DEAD) )  // No idle noises at round start.
 		client->resp.idletime = 0;
-	} else if (!client->resp.idletime) {
+	else if( ! client->resp.idletime )
 		client->resp.idletime = level.framenum;
-	}
 }
 
 /*

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2968,7 +2968,10 @@ void ClientThink(edict_t * ent, usercmd_t * ucmd)
 		client->doortoggle = 0;
 
 		if( client->jumping && (ent->solid != SOLID_NOT) && ! lights_camera_action && ! client->uvTime )
+		{
 			kick_attack( ent );
+			client->punch_desired = false;
+		}
 
 		// touch other objects
 		for (i = 0; i < pm.numtouch; i++) {

--- a/source/p_view.c
+++ b/source/p_view.c
@@ -1438,6 +1438,10 @@ void ClientEndServerFrame (edict_t * ent)
 	ent->client->doortoggle = 0;
 
 
+	// If they just spawned, sync up the weapon animation with that.
+	if( ! ent->client->weapon_last_activity )
+		ent->client->weapon_last_activity = level.framenum;
+
 	qboolean weapon_framesync = (level.framenum % game.framediv == ent->client->weapon_last_activity % game.framediv);
 
 	if (ent->client->reload_attempts > 0)

--- a/source/p_view.c
+++ b/source/p_view.c
@@ -1414,6 +1414,10 @@ void ClientEndServerFrame (edict_t * ent)
 
 	G_SetClientFrame (ent);
 
+	// Raptor007: Fix scooting on platforms if ClientThink didn't happen this frame.
+	if( ent->groundentity && (ent->groundentity->linkcount == ent->groundentity_linkcount + 1) )
+		ent->groundentity_linkcount = ent->groundentity->linkcount;
+
 	if (!FRAMESYNC)
 		return;
 

--- a/source/p_view.c
+++ b/source/p_view.c
@@ -150,7 +150,12 @@ void P_DamageFeedback (edict_t * player)
 	// total points of damage shot at the player this frame
 	count =	client->damage_blood + client->damage_armor + client->damage_parmor;
 	if (count == 0)
+	{
+		if( FRAMESYNC )
+			client->damage_knockback = 0;
+
 		return;			// didn't take any damage
+	}
 
 	// start a pain animation if still in the player model
 	if (client->anim_priority < ANIM_PAIN && player->s.modelindex == 255)
@@ -227,7 +232,6 @@ void P_DamageFeedback (edict_t * player)
 		VectorMA (v, (float) client->damage_blood / realcount, bcolor, v);
 	VectorCopy (v, client->damage_blend);
 
-
 	//
 	// calculate view angle kicks
 	//
@@ -259,7 +263,9 @@ void P_DamageFeedback (edict_t * player)
 	client->damage_blood = 0;
 	client->damage_armor = 0;
 	client->damage_parmor = 0;
-	client->damage_knockback = 0;
+
+	if( FRAMESYNC )
+		client->damage_knockback = 0;
 }
 
 
@@ -465,7 +471,6 @@ void SV_CalcBlend (edict_t * ent)
 	int contents;
 	vec3_t vieworg;
 	int remaining;
-
 
 	// enable ir vision if appropriate
 	if (ir->value)

--- a/source/p_view.c
+++ b/source/p_view.c
@@ -404,6 +404,7 @@ void SV_CalcGunOffset (edict_t * ent)
 	for (i = 0; i < 3; i++)
 	{
 		delta = ent->client->oldviewangles[i] - ent->client->ps.viewangles[i];
+		//delta *= game.framediv;
 		if (delta > 180)
 			delta -= 360;
 		if (delta < -180)
@@ -575,6 +576,9 @@ void P_FallingDamage (edict_t * ent)
 	float delta;
 	int damage;
 	vec3_t dir, oldvelocity;
+
+	//if (!FRAMESYNC)
+	//	return;
 
 	VectorCopy( ent->client->oldvelocity, oldvelocity );
 	VectorCopy( ent->velocity, ent->client->oldvelocity );
@@ -1425,20 +1429,9 @@ void ClientEndServerFrame (edict_t * ent)
 	if( ent->groundentity && (ent->groundentity->linkcount == ent->groundentity_linkcount + 1) )
 		ent->groundentity_linkcount = ent->groundentity->linkcount;
 
-	if (!FRAMESYNC)
-		return;
-
 	// zucc - clear the open door command
 	ent->client->doortoggle = 0;
 
-	if (ent->client->push_timeout > 0)
-		ent->client->push_timeout--;
-  /*              else
-	 {
-	 ent->client->attacker = NULL;
-	 ent->client->attacker_mod = MOD_BLEEDING;
-	 }
-   */
 	if (ent->client->reload_attempts > 0)
 	{
 		if (((ent->client->latched_buttons | ent->client->buttons) & BUTTON_ATTACK)
@@ -1451,8 +1444,24 @@ void ClientEndServerFrame (edict_t * ent)
 			Cmd_Reload_f (ent);
 		}
 	}
+
 	if (ent->client->weapon_attempts > 0)
 		Cmd_Weapon_f (ent);
+
+
+	if (!FRAMESYNC)
+		return;
+
+	if (ent->client->push_timeout > 0)
+		ent->client->push_timeout--;
+	/*
+	else
+	{
+		// Really old code that would prevent kill credits from long-term bleedout.
+		ent->client->attacker = NULL;
+		ent->client->attacker_mod = MOD_BLEEDING;
+	}
+	*/
 
 	RadioThink(ent);
 }

--- a/source/p_view.c
+++ b/source/p_view.c
@@ -1437,20 +1437,18 @@ void ClientEndServerFrame (edict_t * ent)
 	// zucc - clear the open door command
 	ent->client->doortoggle = 0;
 
+
+	qboolean weapon_framesync = (level.framenum % game.framediv == ent->client->weapon_last_activity % game.framediv);
+
 	if (ent->client->reload_attempts > 0)
 	{
-		if (((ent->client->latched_buttons | ent->client->buttons) & BUTTON_ATTACK)
-		&& canFire(ent))
-		{
+		if( ((ent->client->latched_buttons | ent->client->buttons) & BUTTON_ATTACK) && canFire(ent) )
 			ent->client->reload_attempts = 0;
-		}
-		else
-		{
+		else if( weapon_framesync )
 			Cmd_Reload_f (ent);
-		}
 	}
 
-	if (ent->client->weapon_attempts > 0)
+	if( (ent->client->weapon_attempts > 0) && weapon_framesync )
 		Cmd_Weapon_f (ent);
 
 


### PR DESCRIPTION
At the default 10fps, there is an average of 50ms delay between when the server receives your packet and when it processes it in addition to network lag.  The old `sv_fps` code responded to client motion more quickly at higher framerates, but still forced shooting and damage feedback to wait for the `FRAMESYNC` frames at 10fps.  This is no longer the case, so you can now use `sv_fps` to reduce perceived lag (20 fps = 25ms delay, etc).

Fixed platforms moving at the wrong angle with `sv_fps`.

Fixed sliding backwards while standing on a platform with `sv_fps`.

Kicking works like 1.52 again, so you don't kick each other in the same frame.

No longer plays idle sounds at round start after spectating.

Long motd times are better behaved (dismissed during and after LCA).

You can now use `sv resetscores` to reset the timelimit even without matchmode.