### PR TITLE
Allow team join immediately, shorter countdown wait, improved ignore/deadtalk.

### DIFF
--- a/source/a_game.c
+++ b/source/a_game.c
@@ -608,6 +608,8 @@ void EjectBlooder(edict_t * self, vec3_t start, vec3_t veloc)
 // zucc - Adding EjectShell code from action quake, modified for Axshun.
 /********* SHELL EJECTION **************/
 
+void PlaceHolder( edict_t * ent );  // p_weapon.c
+
 void ShellTouch(edict_t * self, edict_t * other, cplane_t * plane, csurface_t * surf)
 {
 	if (self->owner->client->curr_weap == M3_NUM)
@@ -861,7 +863,7 @@ void EjectShell(edict_t * self, vec3_t start, int toggle)
 	shell->owner = self;
 	shell->touch = ShellTouch;
 	shell->nextthink = level.framenum + (shelllife->value - (shells * 0.05)) * HZ;
-	shell->think = ShellDie;
+	shell->think = shelllife->value ? ShellDie : PlaceHolder;
 	shell->classname = "shell";
 	shell->freetime = level.time;  // Used to determine oldest spawned shell.
 
@@ -890,8 +892,6 @@ edict_t *FindEdictByClassnum(char *classname, int classnum)
 }
 
 /********* Bulletholes/wall stuff ***********/
-
-void PlaceHolder( edict_t * ent );  // p_weapon.c
 
 void UpdateAttachedPos( edict_t *self )
 {

--- a/source/a_radio.c
+++ b/source/a_radio.c
@@ -240,8 +240,11 @@ void RadioThink (edict_t * ent)
 			}
 		}
 
-		unicastSound( ent, radio->queue[0].sndIndex, 1.0 );
-		radio->delay = radio->queue[0].length;
+		if( ! IsInIgnoreList( ent, from ) )
+		{
+			unicastSound( ent, radio->queue[0].sndIndex, 1.0 );
+			radio->delay = radio->queue[0].length;
+		}
 		DeleteRadioQueueEntry( radio, 0 ); //We can remove it here?
 	}
 }

--- a/source/a_team.c
+++ b/source/a_team.c
@@ -922,7 +922,8 @@ void Team_f (edict_t * ent)
 		return;
 	}
 
-	if (level.realFramenum - ent->client->resp.joined_team < 5 * HZ) {
+	if( (ent->client->resp.joined_team > 0) && (level.realFramenum - ent->client->resp.joined_team < 5 * HZ) )
+	{
 		gi.cprintf(ent, PRINT_HIGH, "You must wait 5 seconds before changing teams again.\n");
 		return;
 	}

--- a/source/a_vote.c
+++ b/source/a_vote.c
@@ -1685,8 +1685,8 @@ void _AddOrDelIgnoreSubject (edict_t * source, edict_t * subject, qboolean silen
 
 		//Maybe this has to be taken out :)
 
-		if (!silent)
-			gi.cprintf (subject, PRINT_MEDIUM, "\n%s listen to your words.\n",
+		if( ! silent && ! IsInIgnoreList( subject, source ) )
+			gi.cprintf (subject, PRINT_MEDIUM, "\n%s listens to your words.\n",
 				source->client->pers.netname);
 
 		source->client->resp.ignore_time = level.realFramenum;
@@ -1711,7 +1711,7 @@ void _AddOrDelIgnoreSubject (edict_t * source, edict_t * subject, qboolean silen
 
 			//Maybe this has to be taken out :)
 
-			if (!silent)
+			if( ! silent && ! IsInIgnoreList( subject, source ) )
 				gi.cprintf (subject, PRINT_MEDIUM, "\n%s ignores you.\n",
 				source->client->pers.netname);
 		}

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -501,7 +501,7 @@ void InitGame( void )
 	flashtime = gi.cvar ("flashtime", "100", 0);*/
 	//SLIC2
 	sv_shelloff = gi.cvar( "shelloff", "1", 0 );
-	shelllimit = gi.cvar( "shelllimit", "24", 0 );
+	shelllimit = gi.cvar( "shelllimit", "30", 0 );
 	shelllife = gi.cvar( "shelllife", "1.2", 0 );
 	bholelimit = gi.cvar( "bholelimit", "0", 0 );
 	splatlimit = gi.cvar( "splatlimit", "0", 0 );
@@ -526,7 +526,7 @@ void InitGame( void )
 	flood_threshold = gi.cvar( "flood_threshold", "4", 0 );
 
 	warmup = gi.cvar( "warmup", "0", CVAR_LATCH );
-	round_begin = gi.cvar( "round_begin", "20", 0 );
+	round_begin = gi.cvar( "round_begin", "15", 0 );
 	spectator_hud = gi.cvar( "spectator_hud", "0", CVAR_LATCH );
 
 	use_mvd2 = gi.cvar( "use_mvd2", "0", 0 );	// JBravo: q2pro MVD2 recording. 0 = off, 1 = on

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2532,7 +2532,18 @@ void ClientUserinfoChanged(edict_t *ent, char *userinfo)
 		// on the initial update, we won't broadcast the message.
 		if (!client->pers.mvdspec && client->pers.netname[0])
 		{
-			gi.bprintf(PRINT_MEDIUM, "%s is now known as %s.\n", client->pers.netname, tnick);	//TempFile
+			size_t i = 1;
+			for( ; i <= game.maxclients; i ++ )
+			{
+				edict_t *other = &g_edicts[i];
+				if( ! other->inuse || ! other->client )
+					continue;
+				if( team_round_going && (gameSettings & GS_ROUNDBASED) && ! deadtalk->value && ! IS_ALIVE(ent) && IS_ALIVE(other) )
+					continue;
+				if( IsInIgnoreList( other, ent ) )
+					continue;
+				gi.cprintf( other, PRINT_MEDIUM, "%s is now known as %s.\n", client->pers.netname, tnick ); //TempFile
+			}
 			IRC_printf(IRC_T_SERVER, "%n is now known as %n.", client->pers.netname, tnick);
 			nickChanged = true;
 		}


### PR DESCRIPTION
Allow `team` command immediately after the map changes instead of waiting 5 seconds.
Start the countdown after 5 seconds.  You can set `round_begin 20` for the old 10 second wait time.
When you `ignore` someone you won't see their name changes anymore.
Live players won't see dead player name changes unless `deadtalk` is on.