### PR TITLE
Sync_guns for fps sound sync, mapvote_next cvar control, other small stuff.

### DIFF
--- a/source/a_team.c
+++ b/source/a_team.c
@@ -532,7 +532,7 @@ void SelectWeapon0(edict_t *ent, pmenu_t *p)
 	ent->client->pers.chosenWeapon = GET_ITEM(KNIFE_NUM);
 	PMenu_Close(ent);
 	OpenItemMenu(ent);
-	unicastSound(ent, gi.soundindex("weapons/stab.wav"), 1.0);
+	unicastSound(ent, gi.soundindex("weapons/swish.wav"), 1.0);
 }
 
 void SelectWeapon9(edict_t *ent, pmenu_t *p)

--- a/source/a_vote.c
+++ b/source/a_vote.c
@@ -146,6 +146,7 @@ qboolean map_need_to_check_votes;
 cvar_t *mapvote_min;
 cvar_t *mapvote_need;
 cvar_t *mapvote_pass;
+cvar_t *mapvote_next = NULL;
 
 //Igor[Rock] BEGIN
 // moved here from the func ReadMapListFile because I need it global
@@ -331,8 +332,8 @@ void _MapExitLevel (char *NextMap)
 	char buf[MAX_STR_LEN];
 	//Igor[Rock] END
 
-	// Because the current level has ended, ignore minimums required for mapvote.
-	if( _iCheckMapVotes() || (map_num_votes > 0) )
+	// If mapvote_next=1 and level has ended, ignore minimums required for mapvote.
+	if( _iCheckMapVotes() || ((map_num_votes > 0) && mapvote_next && mapvote_next->value) )
 	{
 		votemap = MapWithMostVotes (NULL);
 		Q_strncpyz (NextMap, votemap->mapname, MAX_QPATH);
@@ -480,6 +481,7 @@ cvar_t *_InitMapVotelist (ini_t * ini)
 		ReadIniStr (ini, MAPVOTESECTION, "mapvote_need", buf, "0"), CVAR_LATCH);
 	mapvote_pass = gi.cvar ("mapvote_pass",
 		ReadIniStr (ini, MAPVOTESECTION, "mapvote_pass", buf, "51"), CVAR_LATCH);
+	mapvote_next = gi.cvar( "mapvote_next", "1", 0 );
 
 	return (use_mapvote);
 }

--- a/source/g_cmds.c
+++ b/source/g_cmds.c
@@ -1446,7 +1446,9 @@ void Cmd_Say_f (edict_t * ent, qboolean team, qboolean arg0, qboolean partner_ms
 	// don't let text be too long for malicious reasons
 	if (strlen(text) >= 254)
 		text[254] = 0;
-	
+
+	qboolean show_info = ! strncmp( text + offset_of_text, "!actionversion", 14 );
+
 	//if( IS_ALIVE(ent) )  // Disabled so we parse dead chat too.
 	{
 		s = strchr(text + offset_of_text, '%');
@@ -1498,6 +1500,9 @@ void Cmd_Say_f (edict_t * ent, qboolean team, qboolean arg0, qboolean partner_ms
 		}
 
 		gi.cprintf(other, PRINT_CHAT, "%s", text);
+
+		if( show_info )
+			gi.cprintf( other, PRINT_CHAT, "console: AQ2:TNG %s (%i fps)\n", VERSION, game.framerate );
 	}
 
 }

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -830,7 +830,7 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 		{
 			if (client && attacker->client)
 			{
-				if (!friendlyFire) {
+				if (!friendlyFire && !in_warmup) {
 					attacker->client->resp.damage_dealt += damage;
 					if (mod > 0 && mod < MAX_GUNSTAT) {
 						attacker->client->resp.gunstats[mod].damage += damage;
@@ -885,7 +885,7 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 		}
 		if (attacker->client)
 		{
-			if (!friendlyFire) {
+			if (!friendlyFire && !in_warmup) {
 				attacker->client->resp.damage_dealt += damage;
 				if (mod > 0 && mod < MAX_GUNSTAT) {
 					attacker->client->resp.gunstats[mod].damage += damage;

--- a/source/g_items.c
+++ b/source/g_items.c
@@ -658,7 +658,10 @@ void Use_Silencer (edict_t * ent, gitem_t * item)
 {
 	ent->client->inventory[ITEM_INDEX (item)]--;
 	ValidateSelectedItem (ent);
-	ent->client->silencer_shots += 30;
+	ent->client->silencer_shots += 30;  // For grappling hook?
+
+	// Turn Q2 silencer into AQ2 silencer.
+	AddItem( ent, GET_ITEM(SIL_NUM) );
 
 //      gi.sound(ent, CHAN_ITEM, gi.soundindex("items/damage.wav"), 1, ATTN_NORM, 0);
 }

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1335,6 +1335,7 @@ void Weapon_Generic( edict_t * ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST
 	int FRAME_RELOAD_LAST, int FRAME_LASTRD_LAST,
 	int *pause_frames, int *fire_frames,
 	void( *fire ) (edict_t * ent) );
+void PlayWeaponSound( edict_t *ent );
 
 void P_ProjectSource(gclient_t *client, vec3_t point, vec3_t distance, vec3_t forward, vec3_t right, vec3_t result);
 

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -781,6 +781,7 @@ typedef struct
   int realFramenum; //when game paused, framenum stays the same
   int pauseFrames;
   float matchTime;
+  int weapon_sound_framenum;
 }
 level_locals_t;
 
@@ -969,6 +970,7 @@ extern cvar_t *rrot;
 extern cvar_t *strtwpn;
 extern cvar_t *llsound;
 extern cvar_t *loud_guns;
+extern cvar_t *sync_guns;
 extern cvar_t *use_cvote;
 extern cvar_t *new_irvision;
 extern cvar_t *use_rewards;

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -326,6 +326,7 @@ cvar_t *rrot;			// Random Rotation
 cvar_t *strtwpn;		// Start DM Weapon
 cvar_t *llsound;
 cvar_t *loud_guns;
+cvar_t *sync_guns;
 cvar_t *use_cvote;
 cvar_t *new_irvision;
 cvar_t *use_rewards;

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -422,6 +422,7 @@ void InitGame( void )
 	rrot = gi.cvar( "rrot", "0", 0 );
 	llsound = gi.cvar( "llsound", "0", 0 );
 	loud_guns = gi.cvar( "loud_guns", "1", 0 );
+	sync_guns = gi.cvar( "sync_guns", "1", 0 );
 	use_cvote = gi.cvar( "use_cvote", "0", 0 );	// Removed it from Serverinfo
 	new_irvision = gi.cvar( "new_irvision", "0", 0 );
 	use_rewards = gi.cvar( "use_rewards", "1", 0 );

--- a/source/g_spawn.c
+++ b/source/g_spawn.c
@@ -1383,6 +1383,7 @@ void SP_worldspawn (edict_t * ent)
 	level.realFramenum = 0;
 	level.pauseFrames = 0;
 	level.matchTime = 0;
+	level.weapon_sound_framenum = 0;
 
 	if (st.nextmap)
 		strcpy(level.nextmap, st.nextmap);

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -1360,7 +1360,6 @@ void player_die(edict_t *self, edict_t *inflictor, edict_t *attacker, int damage
 	self->s.angles[2] = 0;
 
 	self->s.sound = 0;
-	self->client->weapon_sound = 0;
 
 	self->maxs[2] = -8;
 
@@ -3133,6 +3132,7 @@ void ClientBeginServerFrame(edict_t * ent)
 
 	// run weapon animations if it hasn't been done by a ucmd_t
 	ClientThinkWeaponIfReady( ent, true );
+	PlayWeaponSound( ent );
 
 	if (ent->deadflag) {
 		// wait for any button just going down

--- a/source/p_view.c
+++ b/source/p_view.c
@@ -967,8 +967,6 @@ void G_SetClientSound (edict_t * ent)
 {
 	if (ent->waterlevel && (ent->watertype & (CONTENTS_LAVA | CONTENTS_SLIME)))
 		ent->s.sound = level.snd_fry;
-	else if (ent->client->weapon_sound)
-		ent->s.sound = ent->client->weapon_sound;
 	else
 		ent->s.sound = 0;
 }

--- a/source/p_weapon.c
+++ b/source/p_weapon.c
@@ -2144,8 +2144,10 @@ void PlayWeaponSound( edict_t *ent )
 	if( ! ent->client->weapon_sound )
 		return;
 
-	// FIXME: Add sync guns cvar and use level.weapon_sync or something like that.
-	if( ! FRAMESYNC )
+	// Synchronize weapon sounds so any framerate sounds like 10fps.
+	if( sync_guns->value
+	&& (level.framenum > level.weapon_sound_framenum)
+	&& (level.framenum < level.weapon_sound_framenum + game.framediv) )
 		return;
 
 
@@ -2195,6 +2197,7 @@ void PlayWeaponSound( edict_t *ent )
 	}
 
 	ent->client->weapon_sound = 0;
+	level.weapon_sound_framenum = level.framenum;
 }
 
 

--- a/source/p_weapon.c
+++ b/source/p_weapon.c
@@ -2145,6 +2145,8 @@ void PlayWeaponSound( edict_t *ent )
 		return;
 
 	// Synchronize weapon sounds so any framerate sounds like 10fps.
+	if( (sync_guns->value == 2) && ! FRAMESYNC )
+		return;
 	if( sync_guns->value
 	&& (level.framenum > level.weapon_sound_framenum)
 	&& (level.framenum < level.weapon_sound_framenum + game.framediv) )

--- a/source/p_weapon.c
+++ b/source/p_weapon.c
@@ -175,6 +175,7 @@ PlayerNoise
 */
 void PlayerNoise (edict_t * who, vec3_t where, int type)
 {
+	/*
 	if (type == PNOISE_WEAPON)
 	{
 		if (who->client->silencer_shots)
@@ -183,6 +184,7 @@ void PlayerNoise (edict_t * who, vec3_t where, int type)
 			return;
 		}
 	}
+	*/
 }
 
 


### PR DESCRIPTION
Server responds to **!actionversion** chat with AQ2 version and framerate.

Added `sync_guns` cvar to synchronize gunshot sounds when multiple players are firing at the same time at sv_fps > 10.  This prevents "machine-gun echo" and is enabled by default.

Added `mapvote_next` cvar to control behavior when the map ends and some mapvotes have been cast, but not enough to trigger an immediate map change.  Default value `1` goes to the most voted map.  Change this to `0` if you want it to stick to the rotation.

Fixed warmup adding to Damage stat.