### PR TITLE
Master: Several small fixes, empty_rotate/empty_exec cvars.

### DIFF
--- a/TNG-manual.txt
+++ b/TNG-manual.txt
@@ -324,10 +324,12 @@ Features
 
 * Empty Rotate
   Prevent unpopular maps from keeping your server empty.  This feature will rotate the map after the server
-  has been empty for some number of minutes.
+  has been empty for some number of minutes.  You can also specify a config file to execute, which can be
+  used to reset the server to default settings after configvote or rotate between multiple mode configs.
 
   Commands:
   empty_rotate [#] - Number of minutes before rotating empty server.  Default 0 disables this feature.
+  empty_exec "file.cfg" - Optional config to exec with empty rotate.  Default blank disables this.
 
 * Bandage Text
   When a client starts bandagine, a message ("You've started bandaging") will appear. Also the Health icon

--- a/TNG-manual.txt
+++ b/TNG-manual.txt
@@ -315,6 +315,20 @@ Features
   Commands:
   vrot [0/1] - Turn on (1), to use voterotation.
 
+* MapVote Next
+  Basically, this is a simplified and immediate form of Vote Rotation.  When the current map ends, if there
+  are any active map votes, the server moves to the most voted map instead of the next in rotation.
+
+  Commands:
+  mapvote_next [0/1] - Default on (1), set to 0 to disable this feature.
+
+* Empty Rotate
+  Prevent unpopular maps from keeping your server empty.  This feature will rotate the map after the server
+  has been empty for some number of minutes.
+
+  Commands:
+  empty_rotate [#] - Number of minutes before rotating empty server.  Default 0 disables this feature.
+
 * Bandage Text
   When a client starts bandagine, a message ("You've started bandaging") will appear. Also the Health icon
   will appear on the bottom of the screen.
@@ -509,7 +523,7 @@ Features
 
   Commands:
   sv_fps [10/20/30/40/50/60] - set server framerate (default is 10)
-  sync_guns [0/1/2] - sync shot sounds: 0 removes lag, 1 syncs when multiple are shooting, 2 forces 10fps (default 1)
+  sync_guns [0/1/2] - 0 plays gun sounds on any frame, 1 syncs with recent shots, 2 delays all to 10fps (default 1)
 
 * Q2pro MVD server demo support
   When AQ2TNG is running under a q2pro Quake2 executable that is properly configured (built with CONFIG_MVD_SERVER

--- a/change.txt
+++ b/change.txt
@@ -100,6 +100,7 @@ From 2.81
 + Can combine use_3team with teamdm or dom mode.
 - When not using maplist.ini, votes are now saved as action.ini-votes instead of maplist.ini-votes.  This fixes vote storage with 'ininame' cvar.
 + Added 'empty_rotate' to rotate maps when empty for that many minutes, to prevent being stuck on an unpopular map.  Default 0 means disabled.
++ Added 'empty_exec' to optionally execute config with empty_rotate.  Useful to revert to default settings on servers with configvote.
 
 From 2.8
 - Radio kill count was missing for falling death

--- a/change.txt
+++ b/change.txt
@@ -98,6 +98,8 @@ From 2.81
 + Added 'loud_guns' to make non-silenced shots heard from farther away.  Default 1 is on, set to 0 for classic sound attenuation.
 + New domination game mode (set 'dom 1') where teams claim flags by touching them and gain points for maintaining control.
 + Can combine use_3team with teamdm or dom mode.
+- When not using maplist.ini, votes are now saved as action.ini-votes instead of maplist.ini-votes.  This fixes vote storage with 'ininame' cvar.
++ Added 'empty_rotate' to rotate maps when empty for that many minutes, to prevent being stuck on an unpopular map.  Default 0 means disabled.
 
 From 2.8
 - Radio kill count was missing for falling death

--- a/source/Makefile
+++ b/source/Makefile
@@ -66,7 +66,7 @@ WIN32=yes
 endif
 
 ifdef WIN32
-#CC=i686-w64-mingw32-gcc
+CC=gcc
 CFLAGS+=-DWIN32
 ARCH=x86
 SHLIBEXT=dll

--- a/source/a_vote.c
+++ b/source/a_vote.c
@@ -1153,7 +1153,7 @@ static void Voteconfig(edict_t *ent, const char *config)
 	}
 
 	if (!*config) {
-		gi.cprintf(ent, PRINT_HIGH, "You need an argument to the vote command (name of config).\n");
+		ConfigVoteMenu( ent, NULL );
 		return;
 	}
 

--- a/source/a_vote.c
+++ b/source/a_vote.c
@@ -696,8 +696,7 @@ void ReadMaplistFile (void)
 	if (maplist_file == NULL)
 	{
 		// no "maplist.ini" file so use the maps from "action.ini"
-		if (num_maps <= 0)
-			return;
+		strcpy( maplistpath, IniPath() );
 
 		for (i = 0; i < num_maps; i++)
 		{

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -532,7 +532,7 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 					Stats_AddHit( attacker, mod, (gotArmor) ? LOC_KVLR_HELMET : LOC_HDAM );
 
 					//AQ2:TNG END
-					if (!friendlyFire)
+					if (!friendlyFire && !in_warmup)
 					{
 						attacker->client->resp.streakHS++;
 						if (attacker->client->resp.streakHS > attacker->client->resp.streakHSHighest)

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -781,6 +781,7 @@ typedef struct
   int realFramenum; //when game paused, framenum stays the same
   int pauseFrames;
   float matchTime;
+  float emptyTime;
   int weapon_sound_framenum;
 }
 level_locals_t;
@@ -967,6 +968,7 @@ extern cvar_t *sv_gib;
 extern cvar_t *sv_crlf;
 extern cvar_t *vrot;
 extern cvar_t *rrot;
+extern cvar_t *empty_rotate;
 extern cvar_t *strtwpn;
 extern cvar_t *llsound;
 extern cvar_t *loud_guns;

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -969,6 +969,7 @@ extern cvar_t *sv_crlf;
 extern cvar_t *vrot;
 extern cvar_t *rrot;
 extern cvar_t *empty_rotate;
+extern cvar_t *empty_exec;
 extern cvar_t *strtwpn;
 extern cvar_t *llsound;
 extern cvar_t *loud_guns;

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -324,6 +324,7 @@ cvar_t *sv_crlf;		// Allow Control Char
 cvar_t *vrot;			// Vote Rotation
 cvar_t *rrot;			// Random Rotation
 cvar_t *empty_rotate;   // Minutes of empty server to automatically rotate map.
+cvar_t *empty_exec;     // Config to exec when empty rotation occurs.
 cvar_t *strtwpn;		// Start DM Weapon
 cvar_t *llsound;
 cvar_t *loud_guns;
@@ -899,6 +900,16 @@ void CheckDMRules (void)
 		if( empty_rotate->value && (level.emptyTime >= (empty_rotate->value * 60.f)) )
 		{
 			level.emptyTime = 0.f;
+
+			// Optional empty_exec to revert to default settings, such as after configvote.
+			// If you only want this to happen once, the file you exec should clear this cvar.
+			if( empty_exec->string && empty_exec->string[0] )
+			{
+				char buf[ 1000 ] = "";
+				Com_sprintf( buf, sizeof(buf), "exec \"%s\"\n", empty_exec->string );
+				gi.AddCommandString( buf );
+			}
+
 			EndDMLevel();
 			return;
 		}

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -422,6 +422,7 @@ void InitGame( void )
 	sv_crlf = gi.cvar( "sv_crlf", "0", CVAR_LATCH ); // 0 == DONT ALLOW IT
 	vrot = gi.cvar( "vrot", "0", 0 );
 	rrot = gi.cvar( "rrot", "0", 0 );
+	empty_rotate = gi.cvar( "empty_rotate", "0", 0 );
 	llsound = gi.cvar( "llsound", "0", 0 );
 	loud_guns = gi.cvar( "loud_guns", "1", 0 );
 	sync_guns = gi.cvar( "sync_guns", "1", 0 );

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -423,6 +423,7 @@ void InitGame( void )
 	vrot = gi.cvar( "vrot", "0", 0 );
 	rrot = gi.cvar( "rrot", "0", 0 );
 	empty_rotate = gi.cvar( "empty_rotate", "0", 0 );
+	empty_exec = gi.cvar( "empty_exec", "", 0 );
 	llsound = gi.cvar( "llsound", "0", 0 );
 	loud_guns = gi.cvar( "loud_guns", "1", 0 );
 	sync_guns = gi.cvar( "sync_guns", "1", 0 );

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -1942,6 +1942,12 @@ void EquipClient(edict_t * ent)
 	if(use_grapple->value)
 		client->inventory[ITEM_INDEX(FindItem("Grapple"))] = 1;
 
+	// Honor changes to wp_flags and itm_flags.
+	if( client->pers.chosenWeapon && ! WPF_ALLOWED(client->pers.chosenWeapon->typeNum) )
+		client->pers.chosenWeapon = NULL;
+	if( client->pers.chosenItem && ! ITF_ALLOWED(client->pers.chosenItem->typeNum) )
+		client->pers.chosenItem = NULL;
+
 	if (client->pers.chosenItem) {
 		if (client->pers.chosenItem->typeNum == BAND_NUM) {
 			band = 1;


### PR DESCRIPTION
Headshot streak disabled during warmup like other stats.

When not using maplist.ini, store votemap data in action.ini-votes instead of maplist.ini-votes.

New `empty_rotate` and `empty_exec` to let the server change map and settings when empty.

If wp_flags or itm_flags changes, don't let players keep spawning with restricted inventory.