### PR TITLE
limp_nopred option for more tolerable play on high ping

### DIFF
--- a/source/a_cmds.c
+++ b/source/a_cmds.c
@@ -803,15 +803,10 @@ void Cmd_Bandage_f(edict_t *ent)
 
 void Bandage(edict_t * ent)
 {
-	ent->client->leg_noise = 0;
-	if (ent->client->leg_damage)
-		ent->client->ps.pmove.pm_flags &= ~PMF_NO_PREDICTION;
-	ent->client->leg_damage = 0;
-	ent->client->leghits = 0;
+	ClientFixLegs(ent);
 	ent->client->bleeding = 0;
 	ent->client->bleed_remain = 0;
 	ent->client->bandaging = 0;
-	ent->client->leg_dam_count = 0;
 	ent->client->attacker = NULL;
 	ent->client->bandage_stopped = 1;
 	ent->client->idle_weapon = BANDAGE_TIME;

--- a/source/a_cmds.c
+++ b/source/a_cmds.c
@@ -804,6 +804,8 @@ void Cmd_Bandage_f(edict_t *ent)
 void Bandage(edict_t * ent)
 {
 	ent->client->leg_noise = 0;
+	if (ent->client->leg_damage)
+		ent->client->ps.pmove.pm_flags &= ~PMF_NO_PREDICTION;
 	ent->client->leg_damage = 0;
 	ent->client->leghits = 0;
 	ent->client->bleeding = 0;

--- a/source/a_ctf.c
+++ b/source/a_ctf.c
@@ -1359,6 +1359,8 @@ void CTFCapReward(edict_t * ent)
 		was_bandaging = 1;
 	
 	ent->client->leg_noise = 0;
+	if (ent->client->leg_damage)
+		ent->client->ps.pmove.pm_flags &= ~PMF_NO_PREDICTION;
 	ent->client->leg_damage = 0;
 	ent->client->leghits = 0;
 	ent->client->bleeding = 0;

--- a/source/a_ctf.c
+++ b/source/a_ctf.c
@@ -1358,15 +1358,10 @@ void CTFCapReward(edict_t * ent)
 	if(ent->client->bandaging || ent->client->bandage_stopped)
 		was_bandaging = 1;
 	
-	ent->client->leg_noise = 0;
-	if (ent->client->leg_damage)
-		ent->client->ps.pmove.pm_flags &= ~PMF_NO_PREDICTION;
-	ent->client->leg_damage = 0;
-	ent->client->leghits = 0;
+	ClientFixLegs(ent);
 	ent->client->bleeding = 0;
 	ent->client->bleed_remain = 0;
 	ent->client->bandaging = 0;
-	ent->client->leg_dam_count = 0;
 	ent->client->attacker = NULL;
 
 	ent->client->bandage_stopped = 0;

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -605,6 +605,8 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 
 				gi.cprintf(targ, PRINT_HIGH, "Leg damage\n");
 				targ->client->leg_damage = 1;
+				if (targ->client->pers.limp_nopred)
+					targ->client->ps.pmove.pm_flags |= PMF_NO_PREDICTION;
 				targ->client->leghits++;
 			}
 			else if (z_rel < STOMACH_DAMAGE)
@@ -715,6 +717,8 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 		{
 			gi.cprintf(targ, PRINT_HIGH, "Leg damage\n");
 			client->leg_damage = 1;
+			if (client->pers.limp_nopred)
+				client->ps.pmove.pm_flags |= PMF_NO_PREDICTION;
 			client->leghits++;
 			//bleeding = 1; for testing
 		}

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -605,8 +605,7 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 
 				gi.cprintf(targ, PRINT_HIGH, "Leg damage\n");
 				targ->client->leg_damage = 1;
-				if (targ->client->pers.limp_nopred)
-					targ->client->ps.pmove.pm_flags |= PMF_NO_PREDICTION;
+				ClientLegDamage(targ);
 				targ->client->leghits++;
 			}
 			else if (z_rel < STOMACH_DAMAGE)
@@ -717,8 +716,7 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 		{
 			gi.cprintf(targ, PRINT_HIGH, "Leg damage\n");
 			client->leg_damage = 1;
-			if (client->pers.limp_nopred)
-				client->ps.pmove.pm_flags |= PMF_NO_PREDICTION;
+			ClientLegDamage(targ);
 			client->leghits++;
 			//bleeding = 1; for testing
 		}

--- a/source/g_combat.c
+++ b/source/g_combat.c
@@ -604,9 +604,7 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 				}
 
 				gi.cprintf(targ, PRINT_HIGH, "Leg damage\n");
-				targ->client->leg_damage = 1;
 				ClientLegDamage(targ);
-				targ->client->leghits++;
 			}
 			else if (z_rel < STOMACH_DAMAGE)
 			{
@@ -715,9 +713,7 @@ T_Damage (edict_t * targ, edict_t * inflictor, edict_t * attacker, vec3_t dir,
 		if (client && targ->health > 0)
 		{
 			gi.cprintf(targ, PRINT_HIGH, "Leg damage\n");
-			client->leg_damage = 1;
 			ClientLegDamage(targ);
-			client->leghits++;
 			//bleeding = 1; for testing
 		}
 	}

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1446,6 +1446,8 @@ typedef struct
 	int menu_shown;		// has the main menu been shown
 	qboolean dm_selected;		// if dm weapon selection has been done once
 
+	qboolean limp_nopred;
+
 	int mk23_mode;		// firing mode, semi or auto
 	int mp5_mode;
 	int m4_mode;

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1106,6 +1106,9 @@ extern cvar_t *bholelife;
 // AQ2 ETE
 extern cvar_t *e_enhancedSlippers;
 
+extern cvar_t *sv_limp_highping;
+
+
 #define world   (&g_edicts[0])
 
 // item spawnflags
@@ -1359,6 +1362,7 @@ void G_UpdatePlayerStatusbar( edict_t *ent, int force );
 edict_t* SelectRandomDeathmatchSpawnPoint(void);
 edict_t* SelectFarthestDeathmatchSpawnPoint(void);
 float PlayersRangeFromSpot(edict_t* spot);
+void ClientLegDamage(edict_t* ent);
 void ClientUserinfoChanged(edict_t* ent, char* userinfo);
 void ClientDisconnect(edict_t* ent);
 void CopyToBodyQue(edict_t* ent);
@@ -1446,7 +1450,7 @@ typedef struct
 	int menu_shown;		// has the main menu been shown
 	qboolean dm_selected;		// if dm weapon selection has been done once
 
-	qboolean limp_nopred;
+	int limp_nopred;
 
 	int mk23_mode;		// firing mode, semi or auto
 	int mp5_mode;

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1363,6 +1363,7 @@ edict_t* SelectRandomDeathmatchSpawnPoint(void);
 edict_t* SelectFarthestDeathmatchSpawnPoint(void);
 float PlayersRangeFromSpot(edict_t* spot);
 void ClientLegDamage(edict_t* ent);
+void ClientFixLegs(edict_t *ent);
 void ClientUserinfoChanged(edict_t* ent, char* userinfo);
 void ClientDisconnect(edict_t* ent);
 void CopyToBodyQue(edict_t* ent);

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -462,6 +462,9 @@ cvar_t *jump;			// jumping mod
 // AQ2 ETE Add
 cvar_t *e_enhancedSlippers;
 
+cvar_t *sv_limp_highping;
+
+
 void SpawnEntities (char *mapname, char *entities, char *spawnpoint);
 void ClientThink (edict_t * ent, usercmd_t * cmd);
 qboolean ClientConnect (edict_t * ent, char *userinfo);

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -543,6 +543,8 @@ void InitGame( void )
 
 	e_enhancedSlippers = gi.cvar( "e_enhancedSlippers", "0", 0); // darksaint: AQ2 ETE
 
+	sv_limp_highping = gi.cvar("sv_limp_highping", "70", CVAR_SERVERINFO);
+
 	// items
 	InitItems();
 

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2594,6 +2594,13 @@ void ClientUserinfoChanged(edict_t *ent, char *userinfo)
 	} else {
 		client->pers.gender = GENDER_NEUTRAL;
 	}
+
+
+	// Reki - disable prediction on limping
+	if (atoi(Info_ValueForKey(userinfo, "limp_nopred")))
+		client->pers.limp_nopred = qtrue;
+	else
+		client->pers.limp_nopred = qfalse;
 }
 
 /*

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2212,6 +2212,9 @@ void ClientLegDamage(edict_t *ent)
 				break;
 			ent->client->pers.limp_nopred |= 256;
 		case 1:
+			if (e_enhancedSlippers->value && INV_AMMO(ent, SLIP_NUM)) // we don't limp with enhanced slippers, so just ignore this leg damage.
+				break;
+
 			ent->client->ps.pmove.pm_flags |= PMF_NO_PREDICTION;
 			break;
 	}

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -2187,6 +2187,9 @@ Called when a player takes leg damage
 
 void ClientLegDamage(edict_t *ent)
 {
+	ent->client->leg_damage = 1;
+	ent->client->leghits++;
+
 	// Reki: limp_nopred behavior
 	switch (ent->client->pers.limp_nopred & 255)
 	{
@@ -2214,6 +2217,19 @@ void ClientLegDamage(edict_t *ent)
 	}
 	//
 
+}
+
+void ClientFixLegs(edict_t *ent)
+{
+	if (ent->client->leg_damage && ent->client->ctf_grapplestate <= CTF_GRAPPLE_STATE_FLY)
+	{
+		ent->client->ps.pmove.pm_flags &= ~PMF_NO_PREDICTION;
+	}
+
+	ent->client->leg_noise = 0;
+	ent->client->leg_damage = 0;
+	ent->client->leghits = 0;
+	ent->client->leg_dam_count = 0;
 }
 
 


### PR DESCRIPTION
New client option which makes use of PMF_NO_PREDICTION while legs are damaged. This prevents the janky warping which can get especially bad on high ping.

I'm new to Q2 modding (but very accustomed to QW modding) so I may have missed a step to initialize the cvar on the client side if that is even a thing. Just a bit clunky that the client would have to do `set limp_nopred 1 u` to initialize it as a userinfo cvar.