### PR TITLE
Updating AQ2-TNG with changes from 2022-2024 (master branch)

### DIFF
--- a/TNG-manual.txt
+++ b/TNG-manual.txt
@@ -581,7 +581,8 @@ Features
   limp_nopred [0/1] - client cvar, clients can set this to force on or off movement prediction when taking leg damage.
   Set to "0" for classic behavior, set to "1" to fix the jitter
 
-
+* Force Spawn items
+  g_spawn_items [0/1] - server cvar, set to "1" to allow for item/ammo/weapon spawns in games that you choose your starting weapon, for example, dm_choose, teamplay, etc.  Forced set to "0" for matchmode.  Set "0" for normal play.
 --------------------------------------------------------------------------------------------------------------------
 Contact Information
   If you wish to contact the TNG team, to report a bug, suggest a new feature, or offer JBravo your

--- a/change.txt
+++ b/change.txt
@@ -6,6 +6,7 @@ Changes in TNG 2.82
 
 From 2.82
 + mapvote_next_limit: Value in seconds, restricts players from voting for a map at the very end of the match while still enabling mapvote_next features
++ New server cvar 'scoreboard' allows customizing fields of second scoreboard screen in team modes.
 + sv_idleremove: Value in seconds, removes player from their team if they reach this amount of total idle time. Set to 0 to disable, Teamplay modes only.
 
 From 2.81
@@ -109,7 +110,7 @@ From 2.81
 + Added 'tourney_lca' server cvar to enable "Lights Camera Action" at the beginning of the round rather than silence.  Set to 0 for classic use, 1 for LCA.
 * Missing action.ini file no longer kills the server, it will default to CTF team names and skins (blue/red/green).  The presence of action.ini will still take precedence
 + Ability to change team names and skins during teamplay with sv t[i]name, sv t[i]skin and sv t[i]skin_index where i is the team number.
-+ Added server cvar "sv_antilag" enables lag-compensation for aiming with hitscan weapons, useful for making high ping games more fair. (Default 0)
++ Added server cvar "sv_antilag" enables lag-compensation for aiming with hitscan weapons, useful for making high ping games more fair. (Default 1)
 + Added server cvar "sv_antilag_interp" accounts for interpolation with antilag, can cause players to be "shot around corners" even on low ping, but you can aim straight on the model. (Default 0)
 + Added server cvar "sv_limp_highping" players above this ping threshold will have movement prediction disabled with leg damage to make things less jittery. (Default 70)
 + Added userinfo Cvar "limp_nopred" clients can set this to force on or off movement prediction when taking leg damage. Legacy behavior would be "setu limp_nopred 0". (Default is decided by sv_limp_highping)

--- a/change.txt
+++ b/change.txt
@@ -8,6 +8,7 @@ From 2.82
 + mapvote_next_limit: Value in seconds, restricts players from voting for a map at the very end of the match while still enabling mapvote_next features
 + New server cvar 'scoreboard' allows customizing fields of second scoreboard screen in team modes.
 + sv_idleremove: Value in seconds, removes player from their team if they reach this amount of total idle time. Set to 0 to disable, Teamplay modes only.
++ g_spawn_items: Value [0/1], set to 1 to allow for item/ammo/weapon spawns in games that you choose your starting weapon.  Set 0 for normal play.
 
 From 2.81
 * 3team mode: third team can not be locked forever anymore
@@ -100,7 +101,7 @@ From 2.81
 + Added 'sv_fps' support for servers that implement variable framerate.  Multiple of 10; higher values reduce lag.  Default value (10) retains old behavior.
 - Climbing down ladders no longer makes a footstep sound every server frame (it sounded awful at higher sv_fps).
 + Added 'sync_guns' for sound timing with sv_fps: 0 plays shots immediately, 1 (default) syncs when multiple are firing, 2 delays all shot sounds to 10fps.
-+ Added 'loud_guns' to make non-silenced shots heard from farther away.  Default 1 is on, set to 0 for classic sound attenuation.
++ Added 'loud_guns' to make non-silenced shots heard from farther away.  Default 0 is off (classic).
 + New domination game mode (set 'dom 1') where teams claim flags by touching them and gain points for maintaining control.
 + Can combine use_3team with teamdm or dom mode.
 - When not using maplist.ini, votes are now saved as action.ini-votes instead of maplist.ini-votes.  This fixes vote storage with 'ininame' cvar.

--- a/source/a_match.c
+++ b/source/a_match.c
@@ -304,7 +304,7 @@ void Cmd_Teamname_f(edict_t * ent)
 		strcpy( temp, "noname" );
 
 	gi.dprintf("%s (team %i) is now known as %s\n", team->name, teamNum, temp);
-	IRC_printf(IRC_T_GAME, "%n (team %i) is now known as %n", team->name, teamNum, temp);
+	IRC_printf(IRC_T_GAME, "%n (team %k) is now known as %n", team->name, teamNum, temp);
 	strcpy(team->name, temp);
 	gi.cprintf(ent, PRINT_HIGH, "New team name: %s\n", team->name);
 

--- a/source/a_vote.c
+++ b/source/a_vote.c
@@ -114,6 +114,14 @@ int _numclients (void)
 		if (!other->inuse || !other->client || !other->client->pers.connected || other->client->pers.mvdspec)
 			continue;
 
+		// Idle players do not count towards voting pool (unless they already voted).
+		if( sv_idleremove->value && ! (other->client->resp.mapvote || other->client->resp.cvote) )
+		{
+			int idleframes = other->client->resp.idletime ? (level.framenum - other->client->resp.idletime) : 0;
+			if( idleframes > sv_idleremove->value * HZ )
+				continue;
+		}
+
 		count++;
 	}
 	return count;

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1126,12 +1126,10 @@ extern cvar_t *medkit_instant;
 
 // BEGIN AQ2 ETE
 extern cvar_t *e_enhancedSlippers;
-
 // END AQ2 ETE
 
 // 2022
 extern cvar_t *sv_limp_highping;
-extern cvar_t *server_id; // Unique server_id
 extern cvar_t *mapvote_next_limit; // Time left that disables map voting
 extern cvar_t *gm; // Gamemode
 extern cvar_t *gmf; // Gamemodeflags
@@ -1537,7 +1535,6 @@ typedef struct
   int team_wounds;
   
   int idletime;
-  int totalidletime;
   int tourneynumber;
   edict_t *kickvote;
 

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1093,6 +1093,7 @@ extern cvar_t *tgren;
 extern cvar_t *allweapon;
 extern cvar_t *allitem;
 extern cvar_t *allow_hoarding; // Allow carrying multiple of the same special item or unique weapon.
+extern cvar_t *grenade_drop;
 
 extern cvar_t *stats_endmap; // If on (1), show the accuracy/etc stats at the end of a map
 extern cvar_t *stats_afterround; // TNG Stats, collect stats between rounds

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1094,6 +1094,7 @@ extern cvar_t *allweapon;
 extern cvar_t *allitem;
 extern cvar_t *allow_hoarding; // Allow carrying multiple of the same special item or unique weapon.
 extern cvar_t *grenade_drop;
+extern cvar_t *grenade_teleport;
 
 extern cvar_t *stats_endmap; // If on (1), show the accuracy/etc stats at the end of a map
 extern cvar_t *stats_afterround; // TNG Stats, collect stats between rounds

--- a/source/g_local.h
+++ b/source/g_local.h
@@ -1134,6 +1134,7 @@ extern cvar_t *mapvote_next_limit; // Time left that disables map voting
 extern cvar_t *gm; // Gamemode
 extern cvar_t *gmf; // Gamemodeflags
 extern cvar_t *sv_idleremove; // Remove idlers
+extern cvar_t *g_spawn_items; // Enables item spawning in GS_WEAPONCHOOSE games
 
 #define world   (&g_edicts[0])
 
@@ -1382,7 +1383,7 @@ void ED_CallSpawn( edict_t *ent );
 char* ED_NewString(char* string);
 void G_UpdateSpectatorStatusbar( void );
 void G_UpdatePlayerStatusbar( edict_t *ent, int force );
-
+int Gamemodeflag(void);
 //
 // p_client.c
 //

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -375,6 +375,7 @@ cvar_t *flashtime;*/
 cvar_t *allweapon;
 cvar_t *allitem;
 cvar_t *allow_hoarding;
+cvar_t *grenade_drop;
 cvar_t *sv_shelloff;
 cvar_t *shelllimit;
 cvar_t *shelllife;

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -474,6 +474,7 @@ cvar_t *mapvote_next_limit;
 cvar_t *sv_idleremove;
 cvar_t *gm;
 cvar_t *gmf;
+cvar_t *g_spawn_items;
 
 void SpawnEntities (char *mapname, char *entities, char *spawnpoint);
 void ClientThink (edict_t * ent, usercmd_t * cmd);

--- a/source/g_main.c
+++ b/source/g_main.c
@@ -376,6 +376,7 @@ cvar_t *allweapon;
 cvar_t *allitem;
 cvar_t *allow_hoarding;
 cvar_t *grenade_drop;
+cvar_t *grenade_teleport;
 cvar_t *sv_shelloff;
 cvar_t *shelllimit;
 cvar_t *shelllife;

--- a/source/g_misc.c
+++ b/source/g_misc.c
@@ -1588,14 +1588,14 @@ SP_func_clock (edict_t * self)
 
 //=================================================================================
 
-void
+void  // FIXME: Clean up this function's formatting.
 teleporter_touch (edict_t * self, edict_t * other, cplane_t * plane,
 		  csurface_t * surf)
 {
   edict_t *dest;
   int i;
 
-  if (!other->client)
+  if( (!other->client) && ((! grenade_teleport->value) || (strcmp(other->classname,"hgrenade") != 0)) )
     return;
   dest = G_Find (NULL, FOFS (targetname), self->target);
   if (!dest)
@@ -1604,26 +1604,34 @@ teleporter_touch (edict_t * self, edict_t * other, cplane_t * plane,
       return;
     }
   
+  if( other->client )
+  {
   // let's be safe, if grapple was disabled but the player has it
   CTFPlayerResetGrapple(other);
 
   // unlink to make sure it can't possibly interfere with KillBox
   gi.unlinkentity (other);
+  }
 
   VectorCopy(dest->s.origin, other->s.origin);
   VectorCopy(dest->s.origin, other->s.old_origin);
   VectorCopy(dest->s.origin, other->old_origin);
   other->s.origin[2] += 10;
 
+  if( other->client )
+  {
   // clear the velocity and hold them in place briefly
   VectorClear (other->velocity);
   other->client->ps.pmove.pm_time = 160 >> 3;	// hold time
   other->client->ps.pmove.pm_flags |= PMF_TIME_TELEPORT;
+  }
 
   // draw the teleport splash at source and on the player
   self->owner->s.event = EV_PLAYER_TELEPORT;
   other->s.event = EV_PLAYER_TELEPORT;
 
+  if( other->client )
+  {
   // set angles
   for (i = 0; i < 3; i++)
     other->client->ps.pmove.delta_angles[i] =
@@ -1635,6 +1643,7 @@ teleporter_touch (edict_t * self, edict_t * other, cplane_t * plane,
 
   // kill anything at the destination
   KillBox (other);
+  }
 
   gi.linkentity (other);
 }

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -548,14 +548,13 @@ void InitGame( void )
 	// END AQ2 ETE
 
 	// 2022
-	server_id = gi.cvar( "server_id", "", 0 ); // Removed it from Serverinfo
-  sv_antilag = gi.cvar("sv_antilag", "1", CVAR_SERVERINFO);
+	sv_antilag = gi.cvar("sv_antilag", "1", CVAR_SERVERINFO);
 	sv_antilag_interp = gi.cvar("sv_antilag_interp", "0", CVAR_SERVERINFO);
 	sv_limp_highping = gi.cvar("sv_limp_highping", "70", 0); // Removed it from Serverinfo
 	mapvote_next_limit = gi.cvar( "mapvote_next_limit", "0", 0);
 	gm = gi.cvar("gm", "dm", CVAR_SERVERINFO);
 	gmf = gi.cvar("gmf", "0", CVAR_SERVERINFO);
-  sv_idleremove = gi.cvar("sv_idleremove", "0", 0);
+	sv_idleremove = gi.cvar("sv_idleremove", "0", 0);
 
 	// items
 	InitItems();

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -503,6 +503,7 @@ void InitGame( void )
 	knifelimit = gi.cvar( "knifelimit", "40", 0 );
 	allweapon = gi.cvar( "allweapon", "0", 0 ); 	// Removed it from Serverinfo
 	allitem = gi.cvar( "allitem", "0", 0 ); 	// Removed it from Serverinfo
+	grenade_drop = gi.cvar( "grenade_drop", "1", 0 );
 	allow_hoarding = gi.cvar( "allow_hoarding", "0", CVAR_LATCH );
 	tgren = gi.cvar( "tgren", "0", CVAR_SERVERINFO );
 	//SLIC2

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -504,6 +504,7 @@ void InitGame( void )
 	allweapon = gi.cvar( "allweapon", "0", 0 ); 	// Removed it from Serverinfo
 	allitem = gi.cvar( "allitem", "0", 0 ); 	// Removed it from Serverinfo
 	grenade_drop = gi.cvar( "grenade_drop", "1", 0 );
+	grenade_teleport = gi.cvar( "grenade_teleport", "0", 0 ); // Allow grenades to use teleporters.
 	allow_hoarding = gi.cvar( "allow_hoarding", "0", CVAR_LATCH );
 	tgren = gi.cvar( "tgren", "0", CVAR_SERVERINFO );
 	//SLIC2

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -427,7 +427,7 @@ void InitGame( void )
 	empty_rotate = gi.cvar( "empty_rotate", "0", 0 );
 	empty_exec = gi.cvar( "empty_exec", "", 0 );
 	llsound = gi.cvar( "llsound", "0", 0 );
-	loud_guns = gi.cvar( "loud_guns", "1", 0 );
+	loud_guns = gi.cvar( "loud_guns", "0", 0 );
 	sync_guns = gi.cvar( "sync_guns", "1", 0 );
 	silentwalk = gi.cvar( "silentwalk", "0", 0 );
 	slopefix = gi.cvar( "slopefix", "1", 0 );
@@ -555,6 +555,7 @@ void InitGame( void )
 	gm = gi.cvar("gm", "dm", CVAR_SERVERINFO);
 	gmf = gi.cvar("gmf", "0", CVAR_SERVERINFO);
 	sv_idleremove = gi.cvar("sv_idleremove", "0", 0);
+	g_spawn_items = gi.cvar("g_spawn_items", "0", CVAR_LATCH);
 
 	// items
 	InitItems();

--- a/source/g_save.c
+++ b/source/g_save.c
@@ -504,7 +504,7 @@ void InitGame( void )
 	allweapon = gi.cvar( "allweapon", "0", 0 ); 	// Removed it from Serverinfo
 	allitem = gi.cvar( "allitem", "0", 0 ); 	// Removed it from Serverinfo
 	grenade_drop = gi.cvar( "grenade_drop", "1", 0 );
-	grenade_teleport = gi.cvar( "grenade_teleport", "0", 0 ); // Allow grenades to use teleporters.
+	grenade_teleport = gi.cvar( "grenade_teleport", "1", 0 ); // Allow grenades to use teleporters.
 	allow_hoarding = gi.cvar( "allow_hoarding", "0", CVAR_LATCH );
 	tgren = gi.cvar( "tgren", "0", CVAR_SERVERINFO );
 	//SLIC2

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -3183,11 +3183,9 @@ void ClientThink(edict_t * ent, usercmd_t * ucmd)
 		}
 	}
 
-	if( ucmd->forwardmove || ucmd->sidemove || client->oldbuttons != client->buttons
-		|| (ent->solid == SOLID_NOT && ent->deadflag != DEAD_DEAD) ) { // No idle noises at round start.
-			client->resp.idletime = 0;
-			client->resp.totalidletime = 0;
-		}
+	if( ucmd->forwardmove || ucmd->sidemove || (client->oldbuttons != client->buttons)
+	|| ((ent->solid == SOLID_NOT) && (ent->deadflag != DEAD_DEAD)) ) // No idle noises at round start.
+		client->resp.idletime = 0;
 	else if( ! client->resp.idletime )
 		client->resp.idletime = level.framenum;
 }
@@ -3326,43 +3324,32 @@ void ClientBeginServerFrame(edict_t * ent)
 		return;
 	}
 
-	if (ent->solid != SOLID_NOT)
+	if( IS_ALIVE(ent) )
 	{
-		int idleframes, remove_idleframes, idler_team;
+		int idleframes = client->resp.idletime ? (level.framenum - client->resp.idletime) : 0;
 
 		if( client->punch_desired && ! client->jumping && ! lights_camera_action && ! client->uvTime )
 			punch_attack( ent );
 		client->punch_desired = false;
 
-		idleframes = ppl_idletime->value * HZ;
-		if( (idleframes > 0) && client->resp.idletime && IS_ALIVE(ent) && (level.framenum >= client->resp.idletime + idleframes) )
-		{
+		if( (ppl_idletime->value > 0) && idleframes && (idleframes % (int)(ppl_idletime->value * HZ) == 0) )
 			//plays a random sound/insane sound, insane1-9.wav
 			gi.sound( ent, CHAN_VOICE, gi.soundindex(va( "insane/insane%i.wav", rand() % 9 + 1 )), 1, ATTN_NORM, 0 );
-			client->resp.totalidletime = client->resp.totalidletime + client->resp.idletime;
-			client->resp.idletime = 0;
-		}
 
-		remove_idleframes = sv_idleremove->value * HZ;
-		if( sv_idleremove->value > 0 && (remove_idleframes > 0) && client->resp.totalidletime &&
-			(level.framenum >= client->resp.totalidletime + remove_idleframes))
+		if( (sv_idleremove->value > 0) && (idleframes > (sv_idleremove->value * HZ)) && client->resp.team )
 		{
-			if (client->resp.team != 0) {
-				// Get team number of idle player
-				idler_team = client->resp.team;
-				// Removes member from team once sv_idleremove value in seconds has been reached in resp.totalidletime
-				if (teamplay->value) {
-					LeaveTeam(ent);
-				}
-				if (matchmode->value) {
-					MM_LeftTeam(ent);
-					teams[idler_team].ready = 0;
-				}
-				client->resp.totalidletime = 0;
-				client->resp.idletime = 0;
-				gi.dprintf("%s has been removed from play due to reaching the sv_idleremove timer of %i seconds\n",
-				client->pers.netname, (int) sv_idleremove->value );
+			// Removes member from team once sv_idleremove value in seconds has been reached
+			int idler_team = client->resp.team;
+			if( teamplay->value )
+				LeaveTeam( ent );
+			if( matchmode->value )
+			{
+				MM_LeftTeam( ent );
+				teams[ idler_team ].ready = 0;
 			}
+			client->resp.idletime = 0;
+			gi.dprintf( "%s has been removed from play due to reaching the sv_idleremove timer of %i seconds\n",
+				client->pers.netname, (int) sv_idleremove->value );
 		}
 
 		if (client->autoreloading && (client->weaponstate == WEAPON_END_MAG)

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -3360,7 +3360,25 @@ void ClientBeginServerFrame(edict_t * ent)
 
 		if (client->uvTime && FRAMESYNC) {
 			client->uvTime--;
-			if (!client->uvTime)
+			if( jump->value )
+			{
+				if( client->uvTime == 42 )
+				{
+					gi.centerprintf( ent, "LIGHTS..." );
+					gi.sound( ent, CHAN_VOICE, gi.soundindex("atl/lights.wav"), 1.0, ATTN_STATIC, 0.0 );
+				}
+				else if( client->uvTime == 22 )
+				{
+					gi.centerprintf( ent, "CAMERA..." );
+					gi.sound( ent, CHAN_VOICE, gi.soundindex("atl/camera.wav"), 1.0, ATTN_STATIC, 0.0 );
+				}
+				else if( client->uvTime == 2 )
+				{
+					gi.centerprintf( ent, "ACTION!" );
+					gi.sound( ent, CHAN_VOICE, gi.soundindex("atl/action.wav"), 1.0, ATTN_STATIC, 0.0 );
+				}
+			}
+			else if (!client->uvTime)
 			{
 				if (team_round_going)
 				{

--- a/source/p_client.c
+++ b/source/p_client.c
@@ -1261,6 +1261,17 @@ void TossItemsOnDeath(edict_t * ent)
 	if (ent->client->inventory[ITEM_INDEX(item)] > 0) {
 		EjectItem(ent, item);
 	}
+
+	if( grenade_drop->value )
+	{
+		item = GET_ITEM(GRENADE_NUM);
+		int drop_count = ent->client->inventory[ ITEM_INDEX(item) ];
+		if( grenade_drop->value < drop_count )
+			drop_count = grenade_drop->value;
+		for( i = 0; i < drop_count; i ++ )
+			EjectItem( ent, item );
+	}
+
 // special items
 
 	if (!DMFLAGS(DF_QUAD_DROP))

--- a/source/p_weapon.c
+++ b/source/p_weapon.c
@@ -2227,7 +2227,7 @@ void Pistol_Fire(edict_t* ent)
 
 	//      gi.cprintf(ent, PRINT_HIGH, "Spread is %d\n", spread);
 
-	if ((ent->client->mk23_rds == 1))
+	if (ent->client->mk23_rds == 1)
 	{
 		//Hard coded for reload only.
 		ent->client->ps.gunframe = 62;

--- a/source/p_weapon.c
+++ b/source/p_weapon.c
@@ -396,7 +396,9 @@ qboolean Pickup_Weapon(edict_t* ent, edict_t* other)
 		return false;
 
 	case GRENADE_NUM:
-		if (!(gameSettings & GS_DEATHMATCH) && ctf->value != 2 && !band)
+		// freud: Teamplay, cannot pick up grenades unless wearing bandolier.
+		// Raptor007: Not sure why, since teamplay already removes grenade spawns. Fixed for grenade_drop.
+		if (!(gameSettings & GS_DEATHMATCH) && (ctf->value != 2) && !band && !(grenade_drop->value))
 			return false;
 
 		if (other->client->inventory[index] >= other->client->grenade_max)

--- a/source/tng_irc.h
+++ b/source/tng_irc.h
@@ -13,9 +13,9 @@
 //
 //-----------------------------------------------------------------------------
 
-#define IRC_SERVER  	"irc.barrysworld.com"
+#define IRC_SERVER  	"irc.aq2world.com"
 #define IRC_PORT    	"6667"
-#define IRC_CHANNEL 	""
+#define IRC_CHANNEL 	"#servermsg"
 #define IRC_CHMODE  	"nt"
 #define IRC_USER    	"TNG-Bot"
 #define IRC_PASSWD  	""

--- a/source/tng_jump.c
+++ b/source/tng_jump.c
@@ -92,6 +92,7 @@ void Cmd_Jmod_f (edict_t *ent)
 		gi.cprintf(ent, PRINT_HIGH, " jmod recall - teleport back to saved point\n");
 		gi.cprintf(ent, PRINT_HIGH, " jmod reset - remove saved point\n");
 		gi.cprintf(ent, PRINT_HIGH, " jmod clear - reset stats\n");
+		gi.cprintf(ent, PRINT_HIGH, " jmod lca - lights camera action\n");
 		return;
 	}
 
@@ -115,6 +116,11 @@ void Cmd_Jmod_f (edict_t *ent)
 	else if(Q_stricmp(cmd, "clear") == 0)
 	{
 		Cmd_Clear_f(ent);
+		return;
+	}
+	else if(Q_stricmp(cmd, "lca") == 0)
+	{
+		Cmd_LCA_f(ent);
 		return;
 	}
 
@@ -218,4 +224,12 @@ void Cmd_Recall_f (edict_t *ent)
 	gi.multicast (ent->s.origin, MULTICAST_PVS);
 
 	ent->movetype = MOVETYPE_WALK;
+}
+
+void Cmd_LCA_f (edict_t *ent)
+{
+	if( IS_ALIVE(ent) && ! ent->client->pers.spectator )
+		ent->client->uvTime = 43;
+	else
+		gi.cprintf( ent, PRINT_HIGH, "This command cannot be used by spectators or dead players\n" );
 }

--- a/source/tng_jump.h
+++ b/source/tng_jump.h
@@ -13,3 +13,4 @@ void Cmd_Clear_f (edict_t *ent);
 void Cmd_Reset_f (edict_t *ent);
 void Cmd_Store_f (edict_t *ent);
 void Cmd_Recall_f (edict_t *ent);
+void Cmd_LCA_f (edict_t *ent);

--- a/source/tng_stats.c
+++ b/source/tng_stats.c
@@ -488,7 +488,7 @@ void Cmd_Statmode_f(edict_t* ent)
 	stuffcmd(ent, stuff);
 }
 
-int Gamemodeflag(void) 
+int Gamemodeflag(void)
 // These are gamemode flags that change the rules of gamemodes.
 // For example, you can have a darkmatch matchmode 3team teamplay server
 {

--- a/source/tng_stats.c
+++ b/source/tng_stats.c
@@ -487,24 +487,3 @@ void Cmd_Statmode_f(edict_t* ent)
 	}
 	stuffcmd(ent, stuff);
 }
-
-int Gamemodeflag(void)
-// These are gamemode flags that change the rules of gamemodes.
-// For example, you can have a darkmatch matchmode 3team teamplay server
-{
-	int gamemodeflag = 0;
-	char gmfstr[16];
-
-	if (use_3teams->value) {
-		gamemodeflag += GMF_3TEAMS;
-	}
-	if (darkmatch->value) {
-		gamemodeflag += GMF_DARKMATCH;
-	}
-	if (matchmode->value) {
-		gamemodeflag += GMF_MATCHMODE;
-	}
-	sprintf(gmfstr, "%d", gamemodeflag);
-	gi.cvar_forceset("gmf", gmfstr);
-	return gamemodeflag;
-}

--- a/source/tng_stats.h
+++ b/source/tng_stats.h
@@ -7,3 +7,4 @@ void A_ScoreboardEndLevel (edict_t * ent, edict_t * killer);
 void Cmd_Stats_f (edict_t *targetent, char *arg);
 void Cmd_Statmode_f(edict_t *ent);
 
+int Gamemodeflag( void );

--- a/source/tng_stats.h
+++ b/source/tng_stats.h
@@ -6,5 +6,3 @@ void Stats_AddHit(edict_t *ent, int gun, int hitPart);
 void A_ScoreboardEndLevel (edict_t * ent, edict_t * killer);
 void Cmd_Stats_f (edict_t *targetent, char *arg);
 void Cmd_Statmode_f(edict_t *ent);
-
-int Gamemodeflag( void );


### PR DESCRIPTION
- Idle players no longer count towards voting minimums.
- Cvar `loud_guns` is no longer enabled by default.
- New cvar `g_spawn_items` allows map items in modes that would normally remove them.
- New cvar `grenade_drop` allows dropping grenades in teamplay (default 1 means drop 1 maximum).
- New cvar `grenade_teleport` allows thrown grenades to teleport.  Enabled (1) by default because most maps have no teleporters, and waldoworldarena is way more fun with this enabled.
- New command `jmod lca` for starting Lights Camera Action in jumpmod.